### PR TITLE
Don't close 416 responses on dotnet

### DIFF
--- a/Core/Extensions/ExceptionExtensions.cs
+++ b/Core/Extensions/ExceptionExtensions.cs
@@ -2,11 +2,15 @@ using System;
 using System.Linq;
 using System.Collections.ObjectModel;
 using System.Runtime.ExceptionServices;
+using System.Diagnostics;
 
 namespace CKAN.Extensions
 {
     public static class ExceptionExtensions
     {
+        #if NET6_0_OR_GREATER
+        [StackTraceHidden]
+        #endif
         public static void RethrowInner(this AggregateException agExc)
         {
             var inner = agExc switch

--- a/Core/Net/ResumingWebClient.cs
+++ b/Core/Net/ResumingWebClient.cs
@@ -135,8 +135,10 @@ namespace CKAN
                   })
             {
                 log.DebugFormat("GetWebResponse failed with range error, closing stream for {0}", request.RequestUri);
-                // Don't save the error page into a file
+                #if NETFRAMEWORK
+                // Don't save the error page into a file (confuses WebClient on dotnet)
                 response.Close();
+                #endif
                 return response;
             }
         }

--- a/Core/Net/ResumingWebClient.cs
+++ b/Core/Net/ResumingWebClient.cs
@@ -124,9 +124,15 @@ namespace CKAN
                 return response;
             }
             catch (WebException wexc)
-            when (wexc.Status == WebExceptionStatus.ProtocolError
-                  && wexc.Response is HttpWebResponse response
-                  && response.StatusCode == HttpStatusCode.RequestedRangeNotSatisfiable)
+            when (wexc is
+                  {
+                      Status:   WebExceptionStatus.ProtocolError,
+                      Response: HttpWebResponse
+                                {
+                                    StatusCode: HttpStatusCode.RequestedRangeNotSatisfiable,
+                                }
+                                response,
+                  })
             {
                 log.DebugFormat("GetWebResponse failed with range error, closing stream for {0}", request.RequestUri);
                 // Don't save the error page into a file

--- a/Core/Platform.cs
+++ b/Core/Platform.cs
@@ -49,9 +49,9 @@ namespace CKAN
         public static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
         #if NET6_0_OR_GREATER
-        [SupportedOSPlatformGuard("windows6.1")]
-        public static readonly bool IsWindows61
-            = IsWindows && OperatingSystem.IsWindowsVersionAtLeast(6, 1);
+        [SupportedOSPlatformGuard("windows11.0")]
+        public static readonly bool IsWindows11
+            =  IsWindows && OperatingSystem.IsWindowsVersionAtLeast(10, 0, 22000);
         #endif
 
         /// <summary>

--- a/GUI/Controls/ThemedTabControl.cs
+++ b/GUI/Controls/ThemedTabControl.cs
@@ -17,11 +17,12 @@ namespace CKAN.GUI
     {
         public ThemedTabControl() : base()
         {
-            // In net10, we use the nice dark mode
-            #if !NET10_0_OR_GREATER
-            // Tell the base class that we want to draw things ourselves
-            DrawMode = TabDrawMode.OwnerDrawFixed;
-            #endif
+            // We need default rendering for dark mode
+            if (!Util.DarkMode)
+            {
+                // Tell the base class that we want to draw things ourselves
+                DrawMode = TabDrawMode.OwnerDrawFixed;
+            }
         }
 
         protected override void OnDrawItem(DrawItemEventArgs e)

--- a/GUI/Dialogs/DownloadsFailedDialog.cs
+++ b/GUI/Dialogs/DownloadsFailedDialog.cs
@@ -1,4 +1,6 @@
 using System;
+using System.IO;
+using System.Net;
 using System.Linq;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -220,7 +222,15 @@ namespace CKAN.GUI
         {
             Retry = true;
             Data  = data;
-            Error = exc.GetBaseException().Message;
+            Error = exc.GetBaseException() switch
+                    {
+                        // For actual download errors, just report the summary
+                        Kraken       k  => k.Message,
+                        WebException we => we.Message,
+                        IOException  ie => ie.Message,
+                        // If something truly unexpected happens, show the stack trace
+                        var          e  => e.ToString(),
+                    };
         }
 
         /// <summary>

--- a/GUI/Util.cs
+++ b/GUI/Util.cs
@@ -469,7 +469,8 @@ namespace CKAN.GUI
 
         public static bool DarkMode => Platform.IsWindows
                                            #if NET10_0_OR_GREATER
-                                           ? WinReg.GetValue(DarkModeKey, "AppsUseLightTheme", 1) is not 1
+                                           ? Platform.IsWindows11
+                                             && WinReg.GetValue(DarkModeKey, "AppsUseLightTheme", 1) is not 1
                                            #else
                                            ? false
                                            #endif

--- a/Tests/Core/IO/ModuleInstallerTests.cs
+++ b/Tests/Core/IO/ModuleInstallerTests.cs
@@ -1763,12 +1763,16 @@ namespace Tests.Core.IO
             }
         }
 
-        [TestCase(true,  true),
-         TestCase(true,  false),
-         TestCase(false, true),
-         TestCase(false, false)]
+        [TestCase(true,  true,  false),
+         TestCase(true,  false, false),
+         TestCase(true,  false, true),
+         TestCase(false, true,  false),
+         TestCase(false, false, false),
+         TestCase(false, false, true),
+        ]
         public void Upgrade_IncompleteInCache_Completes(bool startInstalled,
-                                                        bool withIncomplete)
+                                                        bool withIncomplete,
+                                                        bool withComplete)
         {
             // Arrange
             using (var inst     = new DisposableKSP())
@@ -1789,6 +1793,7 @@ namespace Tests.Core.IO
                 var module      = registry.LatestAvailable("DogeCoinFlag",
                                                            inst.KSP.StabilityToleranceConfig,
                                                            inst.KSP.VersionCriteria())!;
+                module.license  = new List<License> { License.UnknownLicense };
                 module.download = new List<Uri> { new Uri($"{server.Url}/DogeCoinFlag-1.01.zip") };
 
                 if (withIncomplete)
@@ -1798,6 +1803,11 @@ namespace Tests.Core.IO
                     File.WriteAllBytes(filename, File.ReadAllBytes(TestData.DogeCoinFlagZip())
                                                      .Take(20000)
                                                      .ToArray());
+                }
+                else if (withComplete)
+                {
+                    var filename = manager.Cache!.GetInProgressFileName(module)!.FullName;
+                    File.Copy(TestData.DogeCoinFlagZip(), filename);
                 }
                 if (startInstalled)
                 {
@@ -2142,6 +2152,13 @@ namespace Tests.Core.IO
                                        .WithBody(File.ReadAllBytes(TestData.DogeCoinFlagZip())
                                                      .Skip(20000)
                                                      .ToArray()));
+            server.Given(Request.Create()
+                                .WithHeader("Range", new ExactMatcher("bytes=53647-"))
+                                .WithPath("/DogeCoinFlag-1.01.zip")
+                                .UsingGet())
+                  .RespondWith(Response.Create()
+                                       .WithStatusCode(HttpStatusCode.RequestedRangeNotSatisfiable)
+                                       .WithBody("Error page from server"));
             server.Given(Request.Create()
                                 .WithPath("/DogeCoinFlag-1.01.zip")
                                 .UsingGet())

--- a/Tests/Core/Net/ResumingWebClientTests.cs
+++ b/Tests/Core/Net/ResumingWebClientTests.cs
@@ -1,0 +1,52 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Threading;
+
+using NUnit.Framework;
+using WireMock.Server;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+
+using CKAN;
+using Tests.Data;
+
+namespace Tests.Core.Net
+{
+    [TestFixture]
+    public class ResumingWebClientTests
+    {
+        [Test]
+        public void DownloadFileAsyncWithResume_RequestedRangeNotSatisfiable_FileUnchanged()
+        {
+            // Arrange
+            using (var tempDir = new TemporaryDirectory())
+            using (var server  = WireMockServer.Start())
+            {
+                server.Given(Request.Create()
+                                    .WithPath("/")
+                                    .UsingGet())
+                      .RespondWith(Response.Create()
+                                           .WithStatusCode(HttpStatusCode.RequestedRangeNotSatisfiable)
+                                           .WithHeader("Content-Type", "text/plain")
+                                           .WithBody("Error page from server"));
+                var path = Path.Combine(tempDir, "target.zip");
+                File.Copy(TestData.DogeCoinFlagZip(), path);
+                bool done = false;
+                var sut = new ResumingWebClient();
+                sut.DownloadFileCompleted += (_, _) => done = true;
+
+                // Act
+                sut.DownloadFileAsyncWithResume(new Uri(server.Url!), path,
+                                                new FileInfo(path).Length, null);
+                while (!done)
+                {
+                    Thread.Sleep(100);
+                }
+
+                // Assert
+                FileAssert.AreEqual(TestData.DogeCoinFlagZip(), path);
+            }
+        }
+    }
+}

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -151,20 +151,6 @@ public sealed class BuildTask : FrostingTask<BuildContext>
                 Framework     = context.BuildDotNet,
             });
         }
-        if (context.BuildConfiguration == "Release")
-        {
-            var pubSettings = new DotNetPublishSettings
-            {
-                Configuration  = context.BuildConfiguration,
-                Framework      = context.BuildDotNet,
-                Runtime        = "linux-x64",
-                SelfContained  = true,
-            };
-            // Publish Netkan for Inflator and Metadata containers
-            context.DotNetPublish(context.Paths.NetkanProject.FullPath, pubSettings);
-            // Publish Cmdline for Metadata container
-            context.DotNetPublish(context.Paths.CmdlineProject.FullPath, pubSettings);
-        }
     }
 }
 
@@ -219,6 +205,22 @@ public sealed class RepackCkanTask : FrostingTask<BuildContext>
                                                        .CombineWithFilePath("CKAN-CmdLine.exe"),
                              context.Paths.RepackDirectory.Combine(context.BuildConfiguration)
                                                           .CombineWithFilePath("ckan-windows.exe"));
+        }
+
+        if (context.BuildConfiguration == "Release")
+        {
+            var pubSettings = new DotNetPublishSettings
+            {
+                Configuration     = context.BuildConfiguration,
+                Framework         = context.BuildDotNet,
+                Runtime           = "linux-x64",
+                PublishSingleFile = true,
+                SelfContained     = true,
+            };
+            // Publish Netkan for Inflator and Metadata containers
+            context.DotNetPublish(context.Paths.NetkanProject.FullPath, pubSettings);
+            // Publish Cmdline for Metadata container
+            context.DotNetPublish(context.Paths.CmdlineProject.FullPath, pubSettings);
         }
     }
 }


### PR DESCRIPTION
## Problems

- If the in-progress`downloading` folder of the cache contains a completed download for a module, trying to install it throws an exception on the net10 build:
  ```
  System.Net.WebException: An exception occurred during a WebClient request.
   ---> System.ObjectDisposedException: Cannot access a disposed object.
  Object name: 'System.Net.HttpWebResponse'.
     at System.Net.HttpWebResponse.GetResponseStream()
     at System.Net.WebClient.<>c__DisplayClass160_0.<OpenReadAsync>b__0(IAsyncResult iar)
     --- End of inner exception stack trace ---
     at CKAN.NetAsyncModulesDownloader.DownloadModules(IEnumerable`1 modules) in C:\Users\user\github\CKAN\Core\Net\NetAsyncModulesDownloader.cs:line 111
     at CKAN.NetAsyncModulesDownloader.<>c__DisplayClass21_0.<DownloadsCollection>b__1() in C:\Users\user\github\CKAN\Core\Net\NetAsyncModulesDownloader.cs:line 166
     at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
  --- End of stack trace from previous location ---
     at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
     at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
  --- End of stack trace from previous location ---
     at CKAN.NetAsyncModulesDownloader.<>c__DisplayClass21_0.<DownloadsCollection>b__2(Task t) in C:\Users\user\github\CKAN\Core\Net\NetAsyncModulesDownloader.cs:line 173
     at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
  --- End of stack trace from previous location ---
     at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
     at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
  --- End of stack trace from previous location ---
     at CKAN.NetAsyncModulesDownloader.ModulesAsTheyFinish(IReadOnlyCollection`1 cached, Task dlTask, BlockingCollection`1 blockingQueue)+MoveNext() in C:\Users\user\github\CKAN\Core\Net\NetAsyncModulesDownloader.cs:line 157
     at CKAN.IO.ModuleInstaller.ModsInDependencyOrder(RelationshipResolver resolver, IReadOnlyCollection`1 cached, IEnumerable`1downloading)+MoveNext() in C:\Users\user\github\CKAN\Core\IO\ModuleInstaller.cs:line 203
     at CKAN.IO.ModuleInstaller.AddRemove(HashSet`1& possibleConfigOnlyDirs, RegistryManager registry_manager, RelationshipResolver resolver, IReadOnlyCollection`1 add, ISet`1 autoInstalled, IReadOnlyCollection`1 remove, IDownloader downloader, Boolean enforceConsistency, InstalledFilesDeduplicator deduper) in C:\Users\user\github\CKAN\Core\IO\ModuleInstaller.cs:line 1262
     at CKAN.IO.ModuleInstaller.Upgrade(IReadOnlyCollection`1& modules, IDownloader downloader, HashSet`1& possibleConfigOnlyDirs, RegistryManager registry_manager, InstalledFilesDeduplicator deduper, ISet`1 autoInstalled, ISet`1 skipFiles, Boolean enforceConsistency, Boolean ConfirmPrompt) in C:\Users\user\github\CKAN\Core\IO\ModuleInstaller.cs:line 1461
  ```
- A user shared a screenshot with light file and folder icons on a white background:
  <img width="300" alt="image" src="https://github.com/user-attachments/assets/dbb87908-45be-41df-b15d-b1682adb8c35" />
- The tab controls in light mode look different from how they did in previous releases, unintentionally

## Causes

- When the in-progress download file is already completed, the server responds with a 416 status, in response to which we close the response. I think this was a workaround for Mono that also didn't break on Windows at the time, but it does in net10. There must have been some implementation changes to `WebClient` that make it attempt to access the response when it did not in net481.
- `Util.DarkMode` previously checked only that we were running on Windows and that the registry key was set. Unfortunately, the WinForms dark mode does not work on Windows 10 even if the registry key is set, so `Util.DarkMode` was returning true despite the colors being light mode, which caused the colors of the file and folder icons to be inverted.
- `ThemedTabControl` turned off owner drawing for all net10 clients, even if dark mod was not active

## Changes

- Now we only close a 416 response on net481, not on net10.
  Tests are included to exercise this.
  Fixes #4572.
- The failed downloads dialog is updated to display the full stack trace for exceptions that aren't `Kraken`s or `IOException`s or `WebException`s, to make such issues easier to investigate
- Now `Util.DarkMode` checks for Windows 11, so the icons will not be inverted on Windows 10
- Now `ThemedTabControl` uses owner drawing for light mode, so the tabs will look as they did in previous releases
