### PR TITLE
Update .deb package dependencies to support mono 6.14 and later

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -3,7 +3,7 @@ Version: @VERSION@
 Architecture: all
 Section: utils
 Priority: optional
-Depends: mono-runtime (>=5.0), ca-certificates-mono, libmono-microsoft-csharp4.0-cil, libmono-system-net-http-webrequest4.0-cil, libmono-system-servicemodel4.0a-cil, libmono-system-componentmodel-composition4.0-cil
+Depends: mono-runtime (>=5.0), ca-certificates-mono | mono-runtime (>=6.14.1+ds-4), libmono-microsoft-csharp4.0-cil | mono-libraries, libmono-system-net-http-webrequest4.0-cil | mono-libraries, libmono-system-servicemodel4.0a-cil | mono-libraries, libmono-system-componentmodel-composition4.0-cil | mono-libraries
 Maintainer: The CKAN authors <debian@ksp-ckan.space>
 Description: KSP-CKAN official client.
  Official client for the Comprehensive Kerbal Archive Network (CKAN).


### PR DESCRIPTION
Update the .deb package dependencies to work with mono 6.14 and later found in Debian Forky and Ubuntu 26.04.

Fixes https://github.com/KSP-CKAN/CKAN/issues/4590

Debian Forky (currently the testing branch of Debian) has mono 6.14 with condensed packaging compared to mono 6.12. The ca-certificates-mono package is no longer built as of 6.14.1+ds-4, but it is not clear how long it has not been needed. The CKAN dependency on ca-certificates-mono has been changed to also be satisfied by a version of mono-runtime equal to or greater than 6.14.1+ds-4.

All mono library packages were combined into a single new mono-libraries package in 6.14. The mono-libraries package currently uses Provides declarations so the dependencies on the old package names still work but I changed them for CKAN to be optionally met by the mono-libraries package. This was done so that no change will be required in the future if the mono-libraries packages stops providing the virtual package names for the old library packages. The mono-libraries package did not exist prior to 6.14 so this change should have no impact when installing CKAN on a distro release that provides mono 6.12 or older.

Ubuntu 26.04 directly used the Debian mono source package and has the same changes, package names, and package versions. Most downstream distros based on Debian or Ubuntu will likely include these changes to mono packaging in future releases.

