### PR TITLE
Avoid null values for auto-sized columns

### DIFF
--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -299,7 +299,8 @@ namespace CKAN.CmdLine
             // GUI expects its first param to be an identifier, don't confuse it
             GUI.GUI.Main_(args.Except(new string[] {"--verbose", "--debug", "--show-console", "--asroot"})
                               .ToArray(),
-                          options.NetUserAgent, manager, options.ShowConsole);
+                          options.NetUserAgent, manager,
+                          options.ShowConsole || options.Debug || options.Verbose);
 
             return Exit.OK;
         }

--- a/Core/GameInstance.cs
+++ b/Core/GameInstance.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+#if !NET5_0_OR_GREATER
 using System.Reflection;
+#endif
 using System.Text.RegularExpressions;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -70,7 +72,7 @@ namespace CKAN
         [MemberNotNull(nameof(playTime))]
         private void SetupCkanDirectories()
         {
-            log.InfoFormat("Initialising {0}", CkanDir);
+            log.InfoFormat("Initialising {0}", Platform.FormatPath(CkanDir));
 
             // TxFileManager knows if we are in a transaction
             var txFileMgr = new TxFileManager(CkanDir);
@@ -89,7 +91,7 @@ namespace CKAN
                 User.RaiseMessage(Properties.Resources.GameInstanceCreatingDir, InstallHistoryDir);
                 txFileMgr.CreateDirectory(InstallHistoryDir);
             }
-            log.InfoFormat("Initialised {0}", CkanDir);
+            log.InfoFormat("Initialised {0}", Platform.FormatPath(CkanDir));
         }
 
         #endregion

--- a/Core/GameInstanceManager.cs
+++ b/Core/GameInstanceManager.cs
@@ -569,9 +569,9 @@ namespace CKAN
                 var gameName = instance.Item3;
                 try
                 {
-                    var game = KnownGames.knownGames.FirstOrDefault(g => g.ShortName == gameName)
-                        ?? KnownGames.knownGames.First();
-                    log.DebugFormat("Loading {0} from {1}", name, path);
+                    var game = KnownGames.GameByShortName(gameName)
+                               ?? KnownGames.knownGames.First();
+                    log.DebugFormat("Loading {0} from {1}", name, Platform.FormatPath(path));
                     // Add unconditionally, sort out invalid instances downstream
                     instances.Add(name, new GameInstance(game, path, name, User));
                 }

--- a/Core/IO/SteamLibrary.cs
+++ b/Core/IO/SteamLibrary.cs
@@ -28,13 +28,13 @@ namespace CKAN.IO
                 && LibraryFoldersConfigPath(libraryPath) is string libFoldersConfigPath
                 && OpenRead(libFoldersConfigPath) is FileStream stream)
             {
-                log.InfoFormat("Found Steam at {0}", libraryPath);
+                log.InfoFormat("Found Steam at {0}", Platform.FormatPath(libraryPath));
                 var txtParser     = KVSerializer.Create(KVSerializationFormat.KeyValues1Text);
                 var appPaths      = (Utilities.DefaultIfThrows(
                                                    () => DeserializeAll<Dictionary<int, LibraryFolder>>(txtParser, stream),
                                                    exc =>
                                                    {
-                                                       log.Warn($"Failed to parse {libFoldersConfigPath}", exc);
+                                                       log.Warn($"Failed to parse {Platform.FormatPath(libFoldersConfigPath)}", exc);
                                                        return null;
                                                    })
                                               ?.Values
@@ -56,7 +56,7 @@ namespace CKAN.IO
                 Games = steamGames.Concat(nonSteamGames)
                                   .ToArray();
                 log.DebugFormat("Games: {0}",
-                                string.Join(", ", Games.Select(g => $"{g.LaunchUrl} ({g.GameDir})")));
+                                string.Join(", ", Games.Select(g => $"{g.LaunchUrl} ({Platform.FormatPath(g.GameDir?.FullName ?? "")})")));
             }
             else
             {
@@ -81,7 +81,7 @@ namespace CKAN.IO
             => Utilities.DefaultIfThrows(() => File.OpenRead(path),
                                          exc =>
                                          {
-                                             log.Warn($"Failed to open {path}", exc);
+                                             log.Warn($"Failed to open {Platform.FormatPath(path)}", exc);
                                              return null;
                                          });
 
@@ -89,14 +89,14 @@ namespace CKAN.IO
                                                               string       appPath)
             => Utilities.DefaultIfThrows(() => Directory.EnumerateFiles(appPath, "*.acf"),
                                          exc => {
-                                             log.Warn($"Failed to enumerate files for {appPath}", exc);
+                                             log.Warn($"Failed to enumerate files for {Platform.FormatPath(appPath)}", exc);
                                              return null;
                                          })
                         ?.SelectWithCatch(acfFile => DeserializeAll<SteamGame>(acfParser, File.OpenRead(acfFile))
                                                         .NormalizeDir(Path.Combine(appPath, "common")),
                                          (acfFile, exc) =>
                                          {
-                                             log.Warn($"Failed to parse {acfFile}:", exc);
+                                             log.Warn($"Failed to parse {Platform.FormatPath(acfFile)}:", exc);
                                              return default;
                                          })
                          .OfType<GameBase>()
@@ -107,7 +107,7 @@ namespace CKAN.IO
             => Utilities.DefaultIfThrows(() => DeserializeAll<Dictionary<int, NonSteamGame>>(vdfParser, File.OpenRead(path)),
                                          exc =>
                                          {
-                                             log.Warn($"Failed to parse {path}", exc);
+                                             log.Warn($"Failed to parse {Platform.FormatPath(path)}", exc);
                                              return null;
                                          })
                         ?.Values

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -63,7 +63,7 @@ namespace CKAN
             // Create a lock for this registry, so we cannot touch it again.
             if (!GetLock())
             {
-                log.DebugFormat("Unable to acquire registry lock: {0}", lockfilePath);
+                log.DebugFormat("Unable to acquire registry lock: {0}", Platform.FormatPath(lockfilePath));
                 throw new RegistryInUseKraken(lockfilePath);
             }
 
@@ -130,11 +130,11 @@ namespace CKAN
             var directory = gameInstance.CkanDir;
             if (!registryCache.ContainsKey(directory))
             {
-                log.DebugFormat("Registry not in cache at {0}", directory);
+                log.DebugFormat("Registry not in cache at {0}", Platform.FormatPath(directory));
                 return;
             }
 
-            log.DebugFormat("Dispose of registry at {0}", directory);
+            log.DebugFormat("Dispose of registry at {0}", Platform.FormatPath(directory));
             registryCache.Remove(directory);
         }
 
@@ -155,10 +155,10 @@ namespace CKAN
         /// </summary>
         private void CheckStaleLock()
         {
-            log.DebugFormat("Checking for stale lock file at {0}", lockfilePath);
+            log.DebugFormat("Checking for stale lock file at {0}", Platform.FormatPath(lockfilePath));
             if (IsInstanceMaybeLocked(gameInstance.CkanDir))
             {
-                log.DebugFormat("Lock file found at {0}", lockfilePath);
+                log.DebugFormat("Lock file found at {0}", Platform.FormatPath(lockfilePath));
                 string contents;
                 try
                 {
@@ -167,7 +167,7 @@ namespace CKAN
                 catch
                 {
                     // If we can't read the file, we can't check whether it's stale.
-                    log.DebugFormat("Lock file unreadable at {0}", lockfilePath);
+                    log.DebugFormat("Lock file unreadable at {0}", Platform.FormatPath(lockfilePath));
                     return;
                 }
                 log.DebugFormat("Lock file contents: {0}", contents);
@@ -189,7 +189,7 @@ namespace CKAN
                         // so the lock file is stale and we can delete it.
                         try
                         {
-                            log.DebugFormat("Deleting stale lock file at {0}", lockfilePath);
+                            log.DebugFormat("Deleting stale lock file at {0}", Platform.FormatPath(lockfilePath));
                             File.Delete(lockfilePath);
                         }
                         catch
@@ -212,7 +212,7 @@ namespace CKAN
             {
                 CheckStaleLock();
 
-                log.DebugFormat("Trying to create lock file: {0}", lockfilePath);
+                log.DebugFormat("Trying to create lock file: {0}", Platform.FormatPath(lockfilePath));
 
                 lockfileStream = new FileStream(lockfilePath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 512, FileOptions.DeleteOnClose);
 
@@ -221,11 +221,11 @@ namespace CKAN
                 lockfileWriter.Write(Process.GetCurrentProcess().Id);
                 lockfileWriter.Flush();
                 // The lock file is now locked and open.
-                log.DebugFormat("Lock file created: {0}", lockfilePath);
+                log.DebugFormat("Lock file created: {0}", Platform.FormatPath(lockfilePath));
             }
             catch (IOException)
             {
-                log.DebugFormat("Failed to create lock file: {0}", lockfilePath);
+                log.DebugFormat("Failed to create lock file: {0}", Platform.FormatPath(lockfilePath));
                 return false;
             }
 
@@ -241,7 +241,7 @@ namespace CKAN
             // it finds the stream is already disposed.
             if (lockfileWriter != null)
             {
-                log.DebugFormat("Disposing of lock file writer at {0}", lockfilePath);
+                log.DebugFormat("Disposing of lock file writer at {0}", Platform.FormatPath(lockfilePath));
                 lockfileWriter.Dispose();
                 lockfileWriter = null;
             }
@@ -250,7 +250,7 @@ namespace CKAN
             // but we're extra tidy just in case.
             if (lockfileStream != null)
             {
-                log.DebugFormat("Disposing of lock file stream at {0}", lockfilePath);
+                log.DebugFormat("Disposing of lock file stream at {0}", Platform.FormatPath(lockfilePath));
                 lockfileStream.Dispose();
                 lockfileStream = null;
             }
@@ -268,7 +268,7 @@ namespace CKAN
             string directory = inst.CkanDir;
             if (!registryCache.ContainsKey(directory))
             {
-                log.DebugFormat("Preparing to load registry at {0}", directory);
+                log.DebugFormat("Preparing to load registry at {0}", Platform.FormatPath(directory));
                 registryCache[directory] = new RegistryManager(directory, inst, repoData,
                                                                repositories ?? Array.Empty<Repository>());
             }
@@ -323,7 +323,9 @@ namespace CKAN
                 previousCorruptedMessage = exc.Message;
                 previousCorruptedPath    = path + "_CORRUPTED_" + DateTime.Now.ToString("yyyyMMddHHmmss");
                 log.ErrorFormat("{0} is corrupted, archiving to {1}: {2}",
-                    path, previousCorruptedPath, previousCorruptedMessage);
+                    Platform.FormatPath(path),
+                    Platform.FormatPath(previousCorruptedPath),
+                    previousCorruptedMessage);
                 File.Move(path, previousCorruptedPath);
                 Create(repoData, repositories);
             }
@@ -351,7 +353,7 @@ namespace CKAN
         private void Create(RepositoryDataManager   repoData,
                             IEnumerable<Repository> repositories)
         {
-            log.InfoFormat("Creating new CKAN registry at {0}", path);
+            log.InfoFormat("Creating new CKAN registry at {0}", Platform.FormatPath(path));
             registry = new Registry(repoData, repositories);
             AscertainDefaultRepo();
             ScanUnmanagedFiles();
@@ -391,7 +393,7 @@ namespace CKAN
         {
             var txFileMgr = new TxFileManager(gameInstance.CkanDir);
 
-            log.InfoFormat("Saving CKAN registry at {0}", path);
+            log.InfoFormat("Saving CKAN registry at {0}", Platform.FormatPath(path));
 
             if (enforce_consistency)
             {
@@ -403,7 +405,8 @@ namespace CKAN
 
             if (directoryPath == null)
             {
-                log.ErrorFormat("Failed to save registry, invalid path: {0}", path);
+                log.ErrorFormat("Failed to save registry, invalid path: {0}",
+                                Platform.FormatPath(path));
                 throw new DirectoryNotFoundKraken(path, string.Format(
                     Properties.Resources.RegistryManagerDirectoryNotFound, path));
             }
@@ -587,7 +590,7 @@ namespace CKAN
                                      .OfType<IGrouping<string, string>>()
                                      .ToDictionary(grp => grp.Key,
                                                    grp => grp.First());
-                log.DebugFormat("Registering DLLs: {0}", string.Join(", ", dlls.Values));
+                log.DebugFormat("Registering DLLs: {0}", string.Join(", ", dlls.Values.Select(Platform.FormatPath)));
                 var dllChanged = registry.SetDlls(dlls);
 
                 var dlcChanged = ScanDlc();

--- a/GUI/Controls/ManageMods.Designer.cs
+++ b/GUI/Controls/ManageMods.Designer.cs
@@ -370,6 +370,7 @@ namespace CKAN.GUI
             this.ModGrid.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.ModGrid_CellContentClick);
             this.ModGrid.CellMouseDoubleClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.ModGrid_CellMouseDoubleClick);
             this.ModGrid.ColumnHeaderMouseClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.ModGrid_HeaderMouseClick);
+            this.ModGrid.DataError += new System.Windows.Forms.DataGridViewDataErrorEventHandler(this.ModGrid_DataError);
             this.ModGrid.KeyDown += new System.Windows.Forms.KeyEventHandler(this.ModGrid_KeyDown);
             this.ModGrid.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.ModGrid_KeyPress);
             this.ModGrid.MouseDown += new System.Windows.Forms.MouseEventHandler(this.ModGrid_MouseDown);

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -865,9 +865,19 @@ namespace CKAN.GUI
         /// </summary>
         private void ModGrid_KeyDown(object? sender, KeyEventArgs? e)
         {
-            switch (e?.KeyCode)
+            switch (e)
             {
-                case Keys.Home:
+                case { KeyCode: Keys.A, Control: true}:
+                    for (int row = 0; row <  ModGrid.Rows.Count; ++row)
+                    {
+                        ModGrid.Rows[row].Selected = true;
+                    }
+                    e.Handled = true;
+                    break;
+
+                case { KeyCode: Keys.Home, Control: var c, Shift: var s }:
+                    var origSel1 = ModGrid.SelectedRows.OfType<DataGridViewRow>().ToArray();
+                    var bottomRow = ModGrid.CurrentRow;
                     // First row.
                     // Handles for empty filters
                     if (//ModGrid.Rows is [DataGridViewRow top, ..]
@@ -876,11 +886,20 @@ namespace CKAN.GUI
                     {
                         ModGrid.CurrentCell = top.Cells[SelectableColumnIndex()];
                     }
-
+                    if (s && bottomRow is { Index: int maxIndex })
+                    {
+                        ModGrid.SelectRows(0, maxIndex);
+                    }
+                    if (c)
+                    {
+                        ModGrid.SelectRows(origSel1);
+                    }
                     e.Handled = true;
                     break;
 
-                case Keys.End:
+                case { KeyCode: Keys.End, Control: var c, Shift: var s }:
+                    var origSel2 = ModGrid.SelectedRows.OfType<DataGridViewRow>().ToArray();
+                    var topRow = ModGrid.CurrentRow;
                     // Last row.
                     // Handles for empty filters
                     if (//ModGrid.Rows is [.., DataGridViewRow bottom]
@@ -889,11 +908,18 @@ namespace CKAN.GUI
                     {
                         ModGrid.CurrentCell = bottom.Cells[SelectableColumnIndex()];
                     }
-
+                    if (s && topRow is { Index: int minIndex })
+                    {
+                        ModGrid.SelectRows(minIndex, ModGrid.Rows.Count - 1);
+                    }
+                    if (c)
+                    {
+                        ModGrid.SelectRows(origSel2);
+                    }
                     e.Handled = true;
                     break;
 
-                case Keys.Space:
+                case { KeyCode: Keys.Space }:
                     // If they've selected one row and focused one of the checkbox columns,
                     // don't intercept
                     if (ModGrid.SelectedRows   is { Count: > 1 }
@@ -925,7 +951,7 @@ namespace CKAN.GUI
                     }
                     break;
 
-                case Keys.Apps:
+                case { KeyCode: Keys.Apps }:
                     ShowModContextMenu();
                     e.Handled = true;
                     break;

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -768,6 +768,17 @@ namespace CKAN.GUI
             }
         }
 
+        private void ModGrid_DataError(object? sender, DataGridViewDataErrorEventArgs e)
+        {
+            // The grid sometimes raises this after a column becomes visible when some of its cells have null values.
+            // Log and ignore it.
+            log.Debug(string.Format("ModGrid_DataError: row {0}, col {1}, value {2}",
+                                    ModGrid.Rows[e.RowIndex].Tag,
+                                    ModGrid.Columns[e.ColumnIndex].HeaderText,
+                                    Utilities.DefaultIfThrows(() => ModGrid.Rows[e.RowIndex].Cells[e.ColumnIndex])?.Value),
+                      e.Exception);
+        }
+
         private void ShowHeaderContextMenu(bool columns = true,
                                            bool tags    = true)
         {

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -941,18 +941,13 @@ namespace CKAN.GUI
         /// </summary>
         private void ModGrid_KeyPress(object? sender, KeyPressEventArgs? e)
         {
-            if (e != null)
+            // Only search for letters and numbers
+            if (e is { KeyChar: char c }
+                && c.ToString() is string key
+                && !CkanModule.nonAlphaNumsAnyLanguage.IsMatch(key))
             {
-                // Don't search for spaces or newlines
-                if (e.KeyChar is ((char)Keys.Space) or ((char)Keys.Enter))
-                {
-                    return;
-                }
-
-                var key = e.KeyChar.ToString();
                 // Determine time passed since last key press.
-                TimeSpan interval = DateTime.Now - lastSearchTime;
-                if (interval.TotalSeconds < 1)
+                if (DateTime.Now - lastSearchTime is { TotalSeconds: < 1 })
                 {
                     // Last keypress was < 1 sec ago, so combine the last and current keys.
                     key = lastSearchKey + key;

--- a/GUI/Extensions/WinFormsExtensions.cs
+++ b/GUI/Extensions/WinFormsExtensions.cs
@@ -170,5 +170,21 @@ namespace CKAN.GUI
                 }
             }
         }
+
+        public static void SelectRows(this DataGridView grid, int start, int end)
+        {
+            for (int row = start; row <= end; ++row)
+            {
+                grid.Rows[row].Selected = true;
+            }
+        }
+
+        public static void SelectRows(this DataGridView grid, IEnumerable<DataGridViewRow> rows)
+        {
+            foreach (var r in rows.Where(r => r.DataGridView == grid))
+            {
+                r.Selected = true;
+            }
+        }
     }
 }

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -207,35 +207,26 @@ namespace CKAN.GUI
                     Value = "-"
                 };
 
-            var name   = new DataGridViewTextBoxCell { Value = ToGridText(mod.Name)                       };
-            var author = new DataGridViewTextBoxCell { Value = ToGridText(string.Join(", ", mod.Authors)) };
-
-            var installVersion = new DataGridViewTextBoxCell()
-            {
-                Value = mod.InstalledVersion
-            };
-
-            var latestVersion = new DataGridViewTextBoxCell()
-            {
-                Value = mod.LatestVersion
-            };
-
-            var downloadCount = new DataGridViewTextBoxCell { Value = $"{mod.DownloadCount:N0}"   };
-            var compat        = new DataGridViewTextBoxCell { Value = mod.GameCompatibility       };
-            var downloadSize  = new DataGridViewTextBoxCell { Value = mod.DownloadSize            };
-            var installSize   = new DataGridViewTextBoxCell { Value = mod.InstallSize             };
-            var releaseDate   = new DataGridViewTextBoxCell { Value = mod.Module.release_date?.ToLocalTime() };
-            var installDate   = new DataGridViewTextBoxCell { Value = mod.InstallDate             };
-            var desc          = new DataGridViewTextBoxCell
-                                {
-                                    Value       = ToGridText(mod.Abstract),
-                                    ToolTipText = mod.Description is { Length: > 0 }
-                                                      ? string.Join(Environment.NewLine,
-                                                                    graphics.WordWrap(mod.Description, 600)
-                                                                            .Prepend("")
-                                                                            .Prepend(mod.Abstract))
-                                                      : mod.Abstract,
-                                };
+            var name           = new DataGridViewTextBoxCell { Value = ToGridText(mod.Name)                                  };
+            var author         = new DataGridViewTextBoxCell { Value = ToGridText(string.Join(", ", mod.Authors))            };
+            var installVersion = new DataGridViewTextBoxCell { Value = mod.InstalledVersion ?? ""                            };
+            var latestVersion  = new DataGridViewTextBoxCell { Value = mod.LatestVersion                                     };
+            var compat         = new DataGridViewTextBoxCell { Value = mod.GameCompatibility ?? ""                           };
+            var downloadSize   = new DataGridViewTextBoxCell { Value = mod.DownloadSize ?? ""                                };
+            var installSize    = new DataGridViewTextBoxCell { Value = mod.InstallSize                                       };
+            var releaseDate    = new DataGridViewTextBoxCell { Value = (object?)mod.Module.release_date?.ToLocalTime() ?? "" };
+            var installDate    = new DataGridViewTextBoxCell { Value = (object?)mod.InstallDate ?? ""                        };
+            var downloadCount  = new DataGridViewTextBoxCell { Value = $"{mod.DownloadCount:N0}"                             };
+            var desc           = new DataGridViewTextBoxCell
+                                 {
+                                     Value       = ToGridText(mod.Abstract),
+                                     ToolTipText = mod.Description is { Length: > 0 }
+                                                       ? string.Join(Environment.NewLine,
+                                                                     graphics.WordWrap(mod.Description, 600)
+                                                                             .Prepend("")
+                                                                             .Prepend(mod.Abstract))
+                                                       : mod.Abstract,
+                                 };
 
             item.Cells.AddRange(selecting, autoInstalled, updating, replacing, name, author, installVersion, latestVersion, compat, downloadSize, installSize, releaseDate, installDate, downloadCount, desc);
 


### PR DESCRIPTION
## Problems

- Using the search bar occasionally raises a weird DataGridView Default Error Dialog to report `System.FormatException: Formatted value of the cell has a wrong type`
  <img width="394" height="206" alt="Image" src="https://github.com/user-attachments/assets/7d16d3b3-33de-45a5-8e19-72d28c6d651f" />
- While trying to investigate that, I noticed that the `--debug` output cuts off after "Starting the GUI" on Windows unless you pass `--show-console`
- If you press Ctrl+F (or indeed _any_ Ctrl+key), the mod grid's selection is cleared and mod info disappears

## Causes

- If a `DataGridViewColumn` configured to fit its width to the cells' contents is initially hidden and then later made visible, the grid needs to calculate how wide the column should be, which it does by querying the contents of the cells. Somehow, the code that does that does not understand how to handle a `null` cell value, even though every other part of the grid handles this just fine, so it raises the `DataError` event, which shows that weird popup if the owner doesn't handle it.
- If `--show-console` is not passed, the `FreeConsole` API from `kernel32.dll` is used to disconnect from the terminal, so no output is visible past that point. This doesn't make sense when the `--verbose` and `--debug` flags are specifically for letting the user see more output for investigating problems.
- Ctrl+F (or whatever Ctrl+key combo) is treated as a letter to scroll to in the grid (e.g., you can click the grid and type "enviro" to scroll to a mod starting with those letters), but it isn't a letter and isn't present in any mod's name, so no mod is found, and the selection is cleared.

## Changes

- Now cells in the auto-sized columns never have null values.
  Now we handle the grid's `DataError` event to prevent the popup from appearing. You can still see the exception if you really want to by using the `--debug` flag.
  Fixes #4655.
- Now `ckan --debug` and `ckan --verbose` implicitly behave as if `--show-console` was passed, so the output will always be visible.
- Now only actual letters (in any language) and numbers are treated as things to search for, so Ctrl+F won't engage that feature
- Now some new key binds are added to the mod grid:
  - Ctrl+A: Select all rows
  - Shift+Home: Select all rows starting at the current row and going up to the top, de-selecting any previously selected rows
  - Ctrl+Shift+Home: Select all rows starting at the current row and going up to the top, keeping any previously selected rows selected
  - Shift+End: Select all rows starting at the current row and going down to the bottom, de-selecting any previously selected rows
  - Ctrl+Shift+End: Select all rows starting at the current row and going down to the bottom, keeping any previously selected rows selected
- Now various log messages use `\` in paths instead of `/` on Windows, since it looks nicer
