### PR TITLE
Better partial upgrade checking

### DIFF
--- a/Cmdline/Action/List.cs
+++ b/Cmdline/Action/List.cs
@@ -60,11 +60,9 @@ namespace CKAN.CmdLine
             if (exportFileType == null)
             {
                 var installed = new SortedDictionary<string, ModuleVersion>(registry.Installed());
-                var upgradeable = registry
-                                  .CheckUpgradeable(instance, new HashSet<string>())
-                                  [true]
-                                  .Select(m => m.identifier)
-                                  .ToHashSet();
+                var upgradeable = registry.UpgradeableModules(instance, new HashSet<string>())
+                                          .Select(m => m.identifier)
+                                          .ToHashSet();
 
                 foreach (KeyValuePair<string, ModuleVersion> mod in installed)
                 {

--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -73,16 +73,15 @@ namespace CKAN.CmdLine
                                                              repoData);
                 if (options.upgrade_all)
                 {
-                    var to_upgrade = registry
-                                     .CheckUpgradeable(instance, new HashSet<string>())
-                                     [true];
-                    if (to_upgrade.Count == 0)
+                    var to_upgrade = registry.UpgradeableModules(instance, new HashSet<string>())
+                                             .ToArray();
+                    if (to_upgrade.Length == 0)
                     {
                         user.RaiseMessage(Properties.Resources.UpgradeAllUpToDate);
                     }
                     else if (manager.Cache != null)
                     {
-                        UpgradeModules(manager.Cache, options.NetUserAgent, user, instance, deduper, to_upgrade);
+                        UpgradeModules(manager.Cache, options.NetUserAgent, user, instance, deduper, to_upgrade.ToList());
                     }
                 }
                 else
@@ -228,11 +227,9 @@ namespace CKAN.CmdLine
                                                     .OfType<CkanModule>()
                                                     .ToList();
                     // Modules allowed by THOSE modules' relationships
-                    var upgradeable = registry
-                                      .CheckUpgradeable(instance, heldIdents, limiters)
-                                      [true]
-                                      .ToDictionary(m => m.identifier,
-                                                    m => m);
+                    var upgradeable = registry.UpgradeableModulesWithConstraints(instance, limiters, heldIdents)
+                                              .ToDictionary(m => m.identifier,
+                                                            m => m);
                     // Substitute back in the ident=ver requested versions
                     var to_upgrade = new List<CkanModule>();
                     foreach (var request in identsAndVersions)

--- a/ConsoleUI/InstallScreen.cs
+++ b/ConsoleUI/InstallScreen.cs
@@ -114,14 +114,14 @@ namespace CKAN.ConsoleUI {
                                 plan.Install.Clear();
                             }
                             if (plan.Upgrade.Count > 0) {
-                                var upgGroups = registry
-                                                .CheckUpgradeable(manager.CurrentInstance,
-                                                                  // Hold identifiers not chosen for upgrading
-                                                                  registry.Installed(false)
-                                                                          .Keys
-                                                                          .Except(plan.Upgrade)
-                                                                          .ToHashSet());
-                                inst.Upgrade(upgGroups[true], dl, ref possibleConfigOnlyDirs, regMgr, deduper, autoInstalled);
+                                var upgradeable = registry.UpgradeableModules(manager.CurrentInstance,
+                                                                              // Hold identifiers not chosen for upgrading
+                                                                              registry.Installed(false)
+                                                                                      .Keys
+                                                                                      .Except(plan.Upgrade)
+                                                                                      .ToHashSet())
+                                                          .ToArray();
+                                inst.Upgrade(upgradeable, dl, ref possibleConfigOnlyDirs, regMgr, deduper, autoInstalled);
                                 plan.Upgrade.Clear();
                             }
                             if (plan.Replace.Count > 0) {

--- a/ConsoleUI/ModInfoScreen.cs
+++ b/ConsoleUI/ModInfoScreen.cs
@@ -36,7 +36,7 @@ namespace CKAN.ConsoleUI {
                              string?             userAgent,
                              ChangePlan          cp,
                              CkanModule          m,
-                             List<CkanModule>?   upgradeable,
+                             CkanModule[]?       upgradeable,
                              bool                dbg)
             : base(theme)
         {
@@ -47,8 +47,7 @@ namespace CKAN.ConsoleUI {
             this.registry = registry;
             this.userAgent = userAgent;
             this.upgradeable = upgradeable
-                                ?? registry.CheckUpgradeable(instance, new HashSet<string>())
-                                           [true];
+                               ?? registry.UpgradeableModules(instance, new HashSet<string>()).ToArray();
 
             int midL = (Console.WindowWidth / 2) - 1;
 
@@ -345,9 +344,9 @@ namespace CKAN.ConsoleUI {
             return top - 1;
         }
 
-        private string RelationshipString(RelationshipDescriptor rel,
-                                          List<CkanModule>       upgradeable,
-                                          int                    width)
+        private string RelationshipString(RelationshipDescriptor          rel,
+                                          IReadOnlyCollection<CkanModule> upgradeable,
+                                          int                             width)
             => ScreenObject.TruncateLength((ModListScreen.StatusSymbol(
                                                 rel is ModuleRelationshipDescriptor mrd
                                                     // Show install status
@@ -624,7 +623,7 @@ namespace CKAN.ConsoleUI {
         private readonly GameInstanceManager        manager;
         private readonly IRegistryQuerier           registry;
         private readonly string?                    userAgent;
-        private readonly List<CkanModule>           upgradeable;
+        private readonly CkanModule[]               upgradeable;
         private readonly ChangePlan                 plan;
         private readonly CkanModule                 mod;
         private readonly ReleaseStatusComboButtons? stabilityToleranceButtons;

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -104,7 +104,7 @@ namespace CKAN.ConsoleUI {
                             case "i":
                                 return registry.IsInstalled(m.identifier, false);
                             case "u":
-                                return upgradeableGroups?[true].Any(upg => upg.identifier == m.identifier) ?? false;
+                                return upgradeable?.Any(upg => upg.identifier == m.identifier) ?? false;
                             case "n":
                                 // Filter new
                                 return recent.Contains(m.identifier);
@@ -212,7 +212,7 @@ namespace CKAN.ConsoleUI {
             {
                 if (moduleList.Selection != null && manager.CurrentInstance != null) {
                     LaunchSubScreen(new ModInfoScreen(theme, manager, manager.CurrentInstance, registry, userAgent,
-                                                      plan, moduleList.Selection, upgradeableGroups?[true], debug));
+                                                      plan, moduleList.Selection, upgradeable, debug));
                 }
                 return true;
             });
@@ -225,7 +225,7 @@ namespace CKAN.ConsoleUI {
             );
             moduleList.AddTip("+", Properties.Resources.ModListUpgradeTip,
                 () => moduleList.Selection != null && !moduleList.Selection.IsDLC
-                    && (upgradeableGroups?[true].Any(upg => upg.identifier == moduleList.Selection.identifier) ?? false)
+                    && (upgradeable?.Any(upg => upg.identifier == moduleList.Selection.identifier) ?? false)
             );
             moduleList.AddTip("+", Properties.Resources.ModListReplaceTip,
                 () => moduleList.Selection != null
@@ -240,7 +240,7 @@ namespace CKAN.ConsoleUI {
                     if (!registry.IsInstalled(moduleList.Selection.identifier, false)) {
                         plan.ToggleInstall(moduleList.Selection);
                     } else if (registry.IsInstalled(moduleList.Selection.identifier, false)
-                            && (upgradeableGroups?[true].Any(upg => upg.identifier == moduleList.Selection.identifier) ?? false)) {
+                            && (upgradeable?.Any(upg => upg.identifier == moduleList.Selection.identifier) ?? false)) {
                         plan.ToggleUpgrade(moduleList.Selection);
                     } else if (registry.GetReplacement(moduleList.Selection.identifier,
                                                        manager.CurrentInstance.StabilityToleranceConfig,
@@ -437,11 +437,11 @@ namespace CKAN.ConsoleUI {
         }
 
         private bool HasAnyUpgradeable()
-            => (upgradeableGroups?[true].Count ?? 0) > 0;
+            => (upgradeable?.Length ?? 0) > 0;
 
         private bool UpgradeAll()
         {
-            plan.Upgrade.UnionWith(upgradeableGroups?[true].Select(m => m.identifier)
+            plan.Upgrade.UnionWith(upgradeable?.Select(m => m.identifier)
                                    ?? Enumerable.Empty<string>());
             return true;
         }
@@ -684,8 +684,8 @@ namespace CKAN.ConsoleUI {
                             allMods.Add(im.Module);
                         }
                     }
-                    upgradeableGroups = registry
-                                        .CheckUpgradeable(manager.CurrentInstance, new HashSet<string>());
+                    upgradeable = registry.UpgradeableModules(manager.CurrentInstance, new HashSet<string>())
+                                          .ToArray();
                 }
                 return allMods;
             }
@@ -768,7 +768,7 @@ namespace CKAN.ConsoleUI {
         /// </returns>
         public string StatusSymbol(CkanModule m)
             => StatusSymbol(plan.GetModStatus(manager, registry, m.identifier,
-                                              upgradeableGroups?[true] ?? new List<CkanModule>()));
+                                              upgradeable ?? new CkanModule[] {}));
 
         /// <summary>
         /// Return the symbol to use to represent a mod's StatusSymbol.
@@ -807,14 +807,14 @@ namespace CKAN.ConsoleUI {
             return total;
         }
 
-        private readonly GameInstanceManager                 manager;
-        private          RegistryManager                     regMgr;
-        private readonly string?                             userAgent;
-        private          Registry                            registry;
-        private readonly RepositoryDataManager               repoData;
-        private          Dictionary<bool, List<CkanModule>>? upgradeableGroups;
-        private readonly bool                                debug;
-        private          TimeSpan                            timeSinceUpdate = TimeSpan.Zero;
+        private readonly GameInstanceManager             manager;
+        private          RegistryManager                 regMgr;
+        private readonly string?                         userAgent;
+        private          Registry                        registry;
+        private readonly RepositoryDataManager           repoData;
+        private          CkanModule[]?                   upgradeable;
+        private readonly bool                            debug;
+        private          TimeSpan                        timeSinceUpdate = TimeSpan.Zero;
 
         private readonly ConsoleField               searchBox;
         private readonly ConsoleListBox<CkanModule> moduleList;
@@ -931,7 +931,7 @@ namespace CKAN.ConsoleUI {
         public InstallStatus GetModStatus(GameInstanceManager manager,
                                           IRegistryQuerier registry,
                                           string identifier,
-                                          List<CkanModule> upgradeable)
+                                          IReadOnlyCollection<CkanModule> upgradeable)
         {
             if (manager.CurrentInstance != null
                 && registry.IsInstalled(identifier, false)) {

--- a/Core/IO/ModuleInstaller.cs
+++ b/Core/IO/ModuleInstaller.cs
@@ -1665,8 +1665,8 @@ namespace CKAN.IO
                                              recommenders.Concat(recommendations.Keys)
                                                          .Concat(suggestions.Keys))
                                  .Where(kvp => !exclude.Contains(kvp.Key)
-                                               && CanInstall(toInstall.Append(kvp.Key).ToList(),
-                                                          opts, registry, instance.Game, crit))
+                                               && CanInstall(toInstall.Append(kvp.Key).ToList(), toRemove,
+                                                             opts, registry, instance.Game, crit))
                                  .ToDictionary();
 
             return recommendations.Count > 0
@@ -1680,6 +1680,7 @@ namespace CKAN.IO
         /// </summary>
         /// <param name="opts">Installer options</param>
         /// <param name="toInstall">Mods we want to install</param>
+        /// <param name="toRemove">Mods we want to uninstall</param>
         /// <param name="registry">Registry of instance into which we want to install</param>
         /// <param name="game">Game instance</param>
         /// <param name="crit">Game version criteria</param>
@@ -1687,6 +1688,7 @@ namespace CKAN.IO
         /// True if it's possible to install these mods, false otherwise
         /// </returns>
         public static bool CanInstall(IReadOnlyCollection<CkanModule> toInstall,
+                                      IReadOnlyCollection<CkanModule> toRemove,
                                       RelationshipResolverOptions     opts,
                                       IRegistryQuerier                registry,
                                       IGame                           game,
@@ -1695,37 +1697,28 @@ namespace CKAN.IO
             string request = string.Join(", ", toInstall.Select(m => m.identifier));
             try
             {
-                var installed = toInstall.Select(m => registry.InstalledModule(m.identifier)?.Module)
-                                         .OfType<CkanModule>();
-                var resolver = new RelationshipResolver(toInstall, installed, opts, registry, game, crit);
-
+                var resolver = new RelationshipResolver(toInstall, toRemove,
+                                                        opts, registry, game, crit);
                 var resolverModList = resolver.ModList(false).ToArray();
                 if (resolverModList.Length >= toInstall.Count(m => !m.IsMetapackage))
                 {
                     // We can install with no further dependencies
-                    string recipe = string.Join(", ", resolverModList.Select(m => m.identifier));
-                    log.Debug($"Installable: {request}: {recipe}");
+                    log.DebugFormat("Installable: {0}: {1}",
+                                    request, string.Join(", ", resolverModList.Select(m => m.identifier)));
                     return true;
                 }
                 else
                 {
-                    log.DebugFormat("Can't install {0}: {1}", request, string.Join("; ", resolver.ConflictDescriptions));
+                    log.DebugFormat("Can't install {0}: {1}",
+                                    request, string.Join("; ", resolver.ConflictDescriptions));
                     return false;
                 }
             }
             catch (TooManyModsProvideKraken k)
             {
                 // One of the dependencies is virtual
-                foreach (var mod in k.modules)
-                {
-                    // Try each option recursively to see if any are successful
-                    if (CanInstall(toInstall.Append(mod).ToArray(), opts, registry, game, crit))
-                    {
-                        // Child call will emit debug output, so we don't need to here
-                        return true;
-                    }
-                }
-                log.Debug($"Can't install {request}: Can't install provider of {k.requested}");
+                return k.modules.Any(mod => CanInstall(toInstall.Append(mod).ToArray(), toRemove,
+                                                       opts, registry, game, crit));
             }
             catch (InconsistentKraken k)
             {

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 
 using Autofac;
 using log4net;
@@ -175,6 +176,8 @@ namespace CKAN
             => querier.IsInstalled(identifier)
                 && querier.InstalledVersion(identifier) is UnmanagedModuleVersion;
 
+        #region Upgradeability
+
         /// <summary>
         /// Is the mod installed and does it have a newer version compatible with the game instance's version criteria
         /// </summary>
@@ -192,6 +195,7 @@ namespace CKAN
                                      GameInstance?                    instance,
                                      HashSet<string>                  filters,
                                      bool                             checkMissingFiles,
+                                     [NotNullWhen(true)]
                                      out CkanModule?                  latestMod,
                                      IReadOnlyCollection<CkanModule>? installed = null)
         {
@@ -203,131 +207,169 @@ namespace CKAN
                 return false;
             }
             // Check if it's available
-            try
-            {
-                latestMod = querier.LatestAvailable(identifier, stabilityTolerance,
-                                                    instance?.VersionCriteria(), null, installed);
-            }
-            catch
-            {
-                latestMod = null;
-            }
-            if (latestMod == null)
-            {
-                return false;
-            }
-            // Check if the installed module is up to date
-            var comp = latestMod.version.CompareTo(instVer);
-            if (comp == -1
-                || (comp == 0 && !querier.MetadataChanged(identifier, out _)
-                              // Check if any of the files or directories are missing
-                              && (!checkMissingFiles
-                                  || instance == null
-                                  || (querier.InstalledModule(identifier)
-                                             ?.AllFilesExist(instance, filters)
-                                             // Manually installed, consider up to date
-                                             ?? true))))
-            {
-                latestMod = null;
-                return false;
-            }
-            // Checking with a RelationshipResolver here would commit us to
-            // testing against the currently installed modules in the registry,
-            // which could block us from upgrading away from a problem.
-            // Trust our LatestAvailable call above.
-            return true;
+            latestMod = Utilities.DefaultIfThrows(() =>
+                            querier.LatestAvailable(identifier, stabilityTolerance,
+                                                    instance?.VersionCriteria(), null, installed));
+            return latestMod is { IsDLC: false }
+                   && latestMod.version.CompareTo(instVer) switch
+                      {
+                          // Installed version is later, keep it
+                          -1 => false,
+
+                          // Same version, check if there's any reason to re-install
+                          0  => querier.MetadataChanged(identifier, out _)
+                                || (checkMissingFiles
+                                    // Check if any of the files or directories are missing
+                                    && instance != null
+                                    && (!querier.InstalledModule(identifier)
+                                                ?.AllFilesExist(instance, filters)
+                                                // Manually installed, consider up to date
+                                                ?? false)),
+
+                          // Checking with a RelationshipResolver here would commit us to
+                          // testing against the currently installed modules in the registry,
+                          // which could block us from upgrading away from a problem.
+                          // Trust our LatestAvailable call above.
+                          _  => true,
+                      };
         }
 
-        /// <summary>
-        /// Partition the installed mods based on whether they are upgradeable
-        /// </summary>
-        /// <param name="querier">A registry</param>
-        /// <param name="instance">The registry's game instance</param>
-        /// <param name="heldIdents">Identifiers of mods that the user has designated as not to be upgraded</param>
-        /// <param name="ignoreMissingIdents">Identifiers of mods that the user has designated as allowed to have missing files</param>
-        /// <returns>
-        /// Dictionary with true key containing list of upgradeable installed modules
-        /// and false key containing list of non-upgradeable installed modules
-        /// </returns>
-        public static Dictionary<bool, List<CkanModule>> CheckUpgradeable(this IRegistryQuerier querier,
-                                                                          GameInstance          instance,
-                                                                          HashSet<string>       heldIdents,
-                                                                          HashSet<string>?      ignoreMissingIdents = null)
-        {
-            var filters = ServiceLocator.Container.Resolve<IConfiguration>()
-                                                  .GetGlobalInstallFilters(instance.Game)
-                                                  .Concat(instance.InstallFilters)
-                                                  .ToHashSet();
-            // Get the absolute latest versions ignoring restrictions,
-            // to break out of mutual version-depending deadlocks
-            var unlimited = querier.Installed(false)
-                                   .Keys
-                                   .Select(ident => !heldIdents.Contains(ident)
-                                                    && querier.HasUpdate(ident, instance.StabilityToleranceConfig, instance, filters,
-                                                                         !ignoreMissingIdents?.Contains(ident) ?? true,
-                                                                         out CkanModule? latest)
-                                                    && latest is not null
-                                                    && !latest.IsDLC
-                                                        ? latest
-                                                        : querier.GetInstalledVersion(ident))
-                                   .OfType<CkanModule>()
-                                   .ToList();
-            return querier.CheckUpgradeable(instance, heldIdents, unlimited, filters, ignoreMissingIdents);
-        }
+        public static IEnumerable<CkanModule> UpgradeableModules(this IRegistryQuerier querier,
+                                                                 GameInstance          instance,
+                                                                 HashSet<string>       heldIdents,
+                                                                 HashSet<string>?      ignoreMissingIdents = null)
+            => querier.InstalledModulesByUpgradeability(instance, heldIdents, ignoreMissingIdents)
+                      .Where(tuple => tuple.upgradeable)
+                      .Select(tuple => tuple.module);
 
-        /// <summary>
-        /// Partition the installed mods based on whether they are upgradeable
-        /// </summary>
-        /// <param name="querier">A registry</param>
-        /// <param name="instance">The registry's game instance</param>
-        /// <param name="heldIdents">Identifiers of mods that the user has designated as not to be upgraded</param>
-        /// <param name="initial">Installed modules to start out considering as possibly upgradeable, to be checked against each other</param>
-        /// <param name="filters">Install filters that will cause missing files to be skipped</param>
-        /// <param name="ignoreMissingIdents">Identifiers of mods that the user has designated as allowed to have missing files</param>
-        /// <returns>
-        /// Dictionary with true key containing list of upgradeable installed modules
-        /// and false key containing list of non-upgradeable installed modules
-        /// </returns>
-        public static Dictionary<bool, List<CkanModule>> CheckUpgradeable(this IRegistryQuerier querier,
-                                                                          GameInstance          instance,
-                                                                          HashSet<string>       heldIdents,
-                                                                          List<CkanModule>      initial,
-                                                                          HashSet<string>?      filters             = null,
-                                                                          HashSet<string>?      ignoreMissingIdents = null)
+        public static IEnumerable<CkanModule> UpgradeableModulesWithConstraints(
+                this IRegistryQuerier           querier,
+                GameInstance                    instance,
+                IReadOnlyCollection<CkanModule> limiters,
+                HashSet<string>                 heldIdents,
+                HashSet<string>?                ignoreMissingIdents = null)
+            => querier.InstalledModulesByUpgradeabilityWithConstraints(instance, limiters, heldIdents,
+                                                                       ServiceLocator.Container
+                                                                                     .Resolve<IConfiguration>()
+                                                                                     .GetGlobalInstallFilters(instance.Game)
+                                                                                     .Concat(instance.InstallFilters)
+                                                                                     .ToHashSet(),
+                                                                       ignoreMissingIdents)
+                      .Where(tuple => tuple.upgradeable)
+                      .Select(tuple => tuple.module);
+
+        public static (bool upgradeable, CkanModule module)[] InstalledModulesByUpgradeability(
+                this IRegistryQuerier querier,
+                GameInstance          instance,
+                HashSet<string>       heldIdents,
+                HashSet<string>?      ignoreMissingIdents = null)
+            => querier.InstalledModulesByUpgradeability(instance,
+                                                        ServiceLocator.Container
+                                                                      .Resolve<IConfiguration>()
+                                                                      .GetGlobalInstallFilters(instance.Game)
+                                                                      .Concat(instance.InstallFilters)
+                                                                      .ToHashSet(),
+                                                        heldIdents, ignoreMissingIdents);
+
+        private static (bool upgradeable, CkanModule module)[] InstalledModulesByUpgradeability(
+                this IRegistryQuerier querier,
+                GameInstance          instance,
+                HashSet<string>       filters,
+                HashSet<string>       heldIdents,
+                HashSet<string>?      ignoreMissingIdents = null)
+            => querier.FindUpgradeabilitySolutions(instance,
+                                                   querier.Installed(false).Keys,
+                                                   Array.Empty<(bool, CkanModule)>(),
+                                                   filters, heldIdents, ignoreMissingIdents)
+                      // The solutions should already be valid and sorted best to worst, so just take the first
+                      .First();
+
+        private static IEnumerable<(bool upgradeable, CkanModule module)[]> FindUpgradeabilitySolutions(
+                this IRegistryQuerier                   querier,
+                GameInstance                            instance,
+                IReadOnlyCollection<string>             remainingIdents,
+                (bool upgradeable, CkanModule module)[] partialSolution,
+                HashSet<string>                         filters,
+                HashSet<string>                         heldIdents,
+                HashSet<string>?                        ignoreMissingIdents = null)
         {
-            filters ??= ServiceLocator.Container.Resolve<IConfiguration>()
-                                                .GetGlobalInstallFilters(instance.Game)
-                                                .Concat(instance.InstallFilters)
-                                                .ToHashSet();
-            // Use those as the installed modules
-            var upgradeable    = new List<CkanModule>();
-            var notUpgradeable = new List<CkanModule>();
-            foreach (var ident in initial.Select(module => module.identifier))
+            if (remainingIdents.Count == 0)
             {
+                // We are a leaf node, return whatever we received if it is a valid solution
+                if (partialSolution.All(tuple => !tuple.upgradeable)
+                    || Utilities.DefaultIfThrows(() =>
+                           new RelationshipResolver(partialSolution.Where(tuple => tuple.upgradeable)
+                                                                   .Select(tuple => tuple.module),
+                                                    partialSolution.Where(tuple => tuple.upgradeable)
+                                                                   .Select(tuple => tuple.module.identifier)
+                                                                   .Select(querier.GetInstalledVersion)
+                                                                   .OfType<CkanModule>(),
+                                                    RelationshipResolverOptions.DependsOnlyOpts(instance.StabilityToleranceConfig),
+                                                    querier, instance.Game, instance.VersionCriteria()))
+                       is not null)
+                {
+                    yield return partialSolution;
+                }
+                yield break;
+            }
+            foreach (var ident in remainingIdents)
+            {
+                var otherIdents = remainingIdents.Where(i => i != ident)
+                                                 .ToArray();
                 if (!heldIdents.Contains(ident)
                     && querier.HasUpdate(ident, instance.StabilityToleranceConfig, instance, filters,
                                          !ignoreMissingIdents?.Contains(ident) ?? true,
-                                         out CkanModule? latest, initial)
-                    && latest is not null
-                    && !latest.IsDLC)
+                                         out CkanModule? latest,
+                                         partialSolution.Select(tuple => tuple.module)
+                                                        .ToArray()))
                 {
-                    upgradeable.Add(latest);
-                }
-                else
-                {
-                    var current = querier.InstalledModule(ident);
-                    if (current != null && !current.Module.IsDLC)
+                    // Upgrading this mod is allowed so far, use it to check the remaining mods
+                    foreach (var solution in querier.FindUpgradeabilitySolutions(
+                                                 instance, otherIdents,
+                                                 partialSolution.Concat(Enumerable.Repeat((upgradeable: true,
+                                                                                           module:      latest),
+                                                                                          1))
+                                                                .ToArray(),
+                                                 filters, heldIdents, ignoreMissingIdents))
                     {
-                        notUpgradeable.Add(current.Module);
+                        yield return solution;
                     }
                 }
+
+                foreach (var solution in querier.FindUpgradeabilitySolutions(
+                                             instance, otherIdents,
+                                             querier.GetInstalledVersion(ident)
+                                             is { IsDLC: false } imod
+                                                 ? partialSolution.Append((false, imod))
+                                                                  .ToArray()
+                                                 : partialSolution,
+                                             filters, heldIdents, ignoreMissingIdents))
+                {
+                    yield return solution;
+                }
             }
-            return new Dictionary<bool, List<CkanModule>>
-            {
-                { true,  upgradeable    },
-                { false, notUpgradeable },
-            };
         }
+
+        private static IEnumerable<(bool upgradeable, CkanModule module)> InstalledModulesByUpgradeabilityWithConstraints(
+                this IRegistryQuerier           querier,
+                GameInstance                    instance,
+                IReadOnlyCollection<CkanModule> limiters,
+                HashSet<string>                 filters,
+                HashSet<string>                 heldIdents,
+                HashSet<string>?                ignoreMissingIdents = null)
+            => limiters.Select(module => !heldIdents.Contains(module.identifier)
+                                         && querier.HasUpdate(module.identifier,
+                                                              instance.StabilityToleranceConfig,
+                                                              instance, filters,
+                                                              !ignoreMissingIdents?.Contains(module.identifier) ?? true,
+                                                              out CkanModule? latest,
+                                                              limiters)
+                                            ? (true,  latest)
+                                            : (false, querier.InstalledModule(module.identifier)
+                                                      is { Module: { IsDLC: false } imod }
+                                                          ? imod : null))
+                      .Where(tuple => tuple.Item2 != null)
+                      .OfType<(bool upgradeable, CkanModule module)>();
 
         /// <summary>
         /// Check if any important metadata of a module has changed since it was installed
@@ -342,11 +384,10 @@ namespace CKAN
             installedFilesChanged = false;
             try
             {
-                var installed = querier.InstalledModule(identifier)?.Module;
-                return installed != null
-                    && (!querier.GetModuleByVersion(identifier, installed.version)
-                                ?.MetadataEquals(installed, out installedFilesChanged)
-                                ?? false);
+                return querier.InstalledModule(identifier)?.Module is CkanModule installed
+                       && (!querier.GetModuleByVersion(identifier, installed.version)
+                                   ?.MetadataEquals(installed, out installedFilesChanged)
+                                   ?? false);
             }
             catch
             {
@@ -354,6 +395,8 @@ namespace CKAN
                 return false;
             }
         }
+
+        #endregion Upgradeability
 
         /// <summary>
         /// Generate a string describing the range of game versions

--- a/Core/Repositories/BlacklistEntry.cs
+++ b/Core/Repositories/BlacklistEntry.cs
@@ -1,0 +1,19 @@
+using System.Text.RegularExpressions;
+using System.Diagnostics.CodeAnalysis;
+
+namespace CKAN
+{
+    public class BlacklistEntry
+    {
+        [ExcludeFromCodeCoverage]
+        public BlacklistEntry(Regex uri_regex, string description)
+        {
+            this.uri_regex   = uri_regex;
+            this.description = description;
+        }
+
+        public readonly Regex  uri_regex;
+
+        public readonly string description;
+    }
+}

--- a/Core/Repositories/RepositoryDataManager.cs
+++ b/Core/Repositories/RepositoryDataManager.cs
@@ -75,9 +75,9 @@ namespace CKAN
         public int? GetDownloadCount(IEnumerable<Repository>? repos, string identifier)
             => GetRepoDatas(repos).Select(data => data.DownloadCounts)
                                   .OfType<SortedDictionary<string, int>>()
-                                  .Select(counts => counts.GetValueOrDefault(identifier))
-                                  .OfType<int>()
-                                  .FirstOrDefault();
+                                  .Select(counts => counts.TryGetValue(identifier, out int val)
+                                                        ? (int?)val : null)
+                                  .FirstOrDefault(c => c != null);
 
         #endregion
 

--- a/Core/Repositories/RepositoryList.cs
+++ b/Core/Repositories/RepositoryList.cs
@@ -4,9 +4,10 @@ using CKAN.Games;
 
 namespace CKAN
 {
-    public struct RepositoryList
+    public class RepositoryList
     {
-        public Repository[] repositories;
+        public Repository[]     repositories = new Repository[] {};
+        public BlacklistEntry[] blacklist    = new BlacklistEntry[] {};
 
         public static RepositoryList? DefaultRepositories(IGame game, string? userAgent)
         {

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -25,7 +25,7 @@ namespace CKAN
     // Base class for both modules (installed via the CKAN) and bundled
     // modules (which are more lightweight)
     [JsonObject(MemberSerialization.OptIn)]
-    public class CkanModule : IEquatable<CkanModule>
+    public class CkanModule : IEquatable<CkanModule?>
     {
 
         #region Fields
@@ -685,7 +685,7 @@ namespace CKAN
         public override int GetHashCode()
             => (identifier, version).GetHashCode();
 
-        bool IEquatable<CkanModule>.Equals(CkanModule? other)
+        bool IEquatable<CkanModule?>.Equals(CkanModule? other)
             => Equals(other);
 
         /// <summary>

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -287,7 +287,8 @@ namespace CKAN.GUI
                 && ModGrid.Rows.Contains(row)
                 && row.Index >= 0)
             {
-                foreach (DataGridViewCell cell in row.Cells)
+                foreach (var cell in row.Cells.OfType<DataGridViewCell>()
+                                              .Where(c => c.ColumnIndex != Description.Index))
                 {
                     cell.ToolTipText = tooltip;
                 }

--- a/GUI/Controls/ModInfo/Versions.cs
+++ b/GUI/Controls/ModInfo/Versions.cs
@@ -138,6 +138,7 @@ namespace CKAN.GUI
             => module.IsCompatible(crit)
                && currentInstance != null
                && ModuleInstaller.CanInstall(new List<CkanModule>() { module },
+                                             Array.Empty<CkanModule>(),
                                              RelationshipResolverOptions.DependsOnlyOpts(currentInstance.StabilityToleranceConfig),
                                              registry, game, crit);
 

--- a/GUI/Controls/ThemedListView.cs
+++ b/GUI/Controls/ThemedListView.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Drawing;
 using System.Windows.Forms;
 #if NET5_0_OR_GREATER

--- a/GUI/Dialogs/SettingsDialog.cs
+++ b/GUI/Dialogs/SettingsDialog.cs
@@ -444,8 +444,9 @@ namespace CKAN.GUI
         private void NewRepoButton_Click(object? sender, EventArgs? e)
         {
             if (manager?.CurrentInstance != null
-                && RepositoryList.DefaultRepositories(manager.CurrentInstance.Game, userAgent)?.repositories
-                   is Repository[] repos)
+                && RepositoryList.DefaultRepositories(manager.CurrentInstance.Game, userAgent)
+                   is { repositories: Repository[]     repos,
+                        blacklist:    BlacklistEntry[] blacklist })
             {
                 var dialog = new NewRepoDialog(repos);
                 if (dialog.ShowDialog(this) == DialogResult.OK)
@@ -455,6 +456,15 @@ namespace CKAN.GUI
                     if (registry.Repositories.Values.Any(other => other.uri == repo.uri))
                     {
                         user.RaiseError(Properties.Resources.SettingsDialogRepoAddDuplicateURL, repo.uri);
+                        return;
+                    }
+                    if (blacklist.Where(ble => ble.uri_regex.IsMatch(repo.uri.OriginalString))
+                                 .ToArray()
+                        is { Length: > 0 } matches)
+                    {
+                        user.RaiseError(Properties.Resources.SettingsDialogRepoAddBlacklist,
+                                        string.Join(Environment.NewLine,
+                                                    matches.Select(m => m.description)));
                         return;
                     }
                     if (registry.Repositories.TryGetValue(repo.name, out Repository? existing))

--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -270,8 +270,17 @@ namespace CKAN.GUI
                                            .ToArray());
 
             HasReplacement = registry.GetReplacement(mod, stabilityTolerance, instance.VersionCriteria()) != null;
-            DownloadSize   = mod.download_size == 0 ? Properties.Resources.GUIModNSlashA : CkanModule.FmtSize(mod.download_size);
-            InstallSize    = mod.install_size  == 0 ? Properties.Resources.GUIModNSlashA : CkanModule.FmtSize(mod.install_size);
+            if (mod.IsMetapackage)
+            {
+                // Nothing to download or install
+                DownloadSize = Properties.Resources.GUIModNSlashA;
+                InstallSize  = Properties.Resources.GUIModNSlashA;
+            }
+            else
+            {
+                DownloadSize = mod.download_size == 0 ? "" : CkanModule.FmtSize(mod.download_size);
+                InstallSize  = mod.install_size  == 0 ? "" : CkanModule.FmtSize(mod.install_size);
+            }
 
             // Get the Searchables.
             SearchableName        = mod.SearchableName;

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -517,37 +517,45 @@ namespace CKAN.GUI
                 }
             }
 
-            var installedModules = registry.InstalledModules
-                                           .ToDictionary(imod => imod.Module.identifier,
-                                                         imod => imod.Module);
-
-            foreach (var dependent in registry.FindReverseDependencies(
-                                          toRemove.Select(mod => mod.identifier)
-                                                  .Except(toInstall.Select(m => m.identifier))
-                                                  .ToList(),
-                                          toInstall))
+            // Check for depending mods if any are still left
+            if (!registry.InstalledModules.Select(im => im.Module)
+                                          .All(toRemove.Contains))
             {
-                if (!changeSet.Any(ch => ch.ChangeType == GUIModChangeType.Replace
-                                         && ch.Mod.identifier == dependent)
-                    && installedModules.TryGetValue(dependent, out CkanModule? depMod)
-                    && (registry.GetModuleByVersion(depMod.identifier, depMod.version)
-                        ?? registry.InstalledModule(dependent)?.Module)
-                        is CkanModule modByVer)
+                var installedModules = registry.InstalledModules.ToDictionary(
+                                           imod => imod.Module.identifier,
+                                           imod => imod.Module);
+                foreach (var dependent in registry.FindReverseDependencies(
+                                              toRemove.Select(mod => mod.identifier)
+                                                      .Except(toInstall.Select(m => m.identifier))
+                                                      .ToList(),
+                                              toInstall))
                 {
-                    changeSet.Add(new ModChange(modByVer, GUIModChangeType.Remove,
-                                                new SelectionReason.DependencyRemoved(),
-                                                coreConfig));
-                    toRemove.Add(modByVer);
+                    if (!changeSet.Any(ch => ch.ChangeType == GUIModChangeType.Replace
+                                             && ch.Mod.identifier == dependent)
+                        && installedModules.TryGetValue(dependent, out CkanModule? depMod)
+                        && (registry.GetModuleByVersion(depMod.identifier, depMod.version)
+                            ?? registry.InstalledModule(dependent)?.Module)
+                            is CkanModule modByVer)
+                    {
+                        changeSet.Add(new ModChange(modByVer, GUIModChangeType.Remove,
+                                                    new SelectionReason.DependencyRemoved(),
+                                                    coreConfig));
+                        toRemove.Add(modByVer);
+                    }
                 }
-            }
-
-            foreach (var im in registry.FindRemovableAutoInstalled(
-                InstalledAfterChanges(registry, changeSet).ToArray(),
-                Array.Empty<CkanModule>(), game, stabilityTolerance, version))
-            {
-                changeSet.Add(new ModChange(im.Module, GUIModChangeType.Remove, new SelectionReason.NoLongerUsed(),
-                                            coreConfig));
-                toRemove.Add(im.Module);
+                // Check for auto-installed dependencies if any mods are still left
+                if (!registry.InstalledModules.Select(im => im.Module)
+                                              .All(toRemove.Contains))
+                {
+                    foreach (var im in registry.FindRemovableAutoInstalled(
+                        InstalledAfterChanges(registry, changeSet).ToArray(),
+                        Array.Empty<CkanModule>(), game, stabilityTolerance, version))
+                    {
+                        changeSet.Add(new ModChange(im.Module, GUIModChangeType.Remove, new SelectionReason.NoLongerUsed(),
+                                                    coreConfig));
+                        toRemove.Add(im.Module);
+                    }
+                }
             }
 
             // Get as many dependencies as we can, but leave decisions and prompts for installation time

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -100,31 +100,29 @@ namespace CKAN.GUI
                                                       NetModuleCache        cache,
                                                       bool                  hideEpochs,
                                                       bool                  hideV)
-            => registry.CheckUpgradeable(inst,
-                                         allLabels.HeldIdentifiers(inst)
-                                                  .ToHashSet(),
-                                         allLabels.IgnoreMissingIdentifiers(inst)
-                                                  .ToHashSet())
-                       .SelectMany(kvp => kvp.Value
-                                             .Select(mod => registry.IsAutodetected(mod.identifier)
-                                                            ? new GUIMod(mod, repoData, registry,
-                                                                         inst.StabilityToleranceConfig,
-                                                                         inst, cache, null,
-                                                                         hideEpochs, hideV)
-                                                              {
-                                                                  HasUpdate = kvp.Key,
-                                                              }
-                                                            : registry.InstalledModule(mod.identifier)
-                                                              is InstalledModule found
-                                                              ? new GUIMod(found,
-                                                                           repoData, registry,
-                                                                           inst.StabilityToleranceConfig,
-                                                                           inst, cache, null,
-                                                                           hideEpochs, hideV)
-                                                              {
-                                                                  HasUpdate = kvp.Key,
-                                                              }
-                                                              : null))
+            => registry.InstalledModulesByUpgradeability(inst,
+                                                         allLabels.HeldIdentifiers(inst)
+                                                                  .ToHashSet(),
+                                                         allLabels.IgnoreMissingIdentifiers(inst)
+                                                                  .ToHashSet())
+                       .Select(tuple => registry.IsAutodetected(tuple.Item2.identifier)
+                                            ? new GUIMod(tuple.Item2, repoData, registry,
+                                                         inst.StabilityToleranceConfig,
+                                                         inst, cache, null,
+                                                         hideEpochs, hideV)
+                                              {
+                                                  HasUpdate = tuple.Item1,
+                                              }
+                                            : registry.InstalledModule(tuple.Item2.identifier)
+                                              is InstalledModule found
+                                                  ? new GUIMod(found, repoData, registry,
+                                                               inst.StabilityToleranceConfig,
+                                                               inst, cache, null,
+                                                               hideEpochs, hideV)
+                                                    {
+                                                        HasUpdate = tuple.Item1,
+                                                    }
+                                                  : null)
                        .OfType<GUIMod>()
                        .Concat(registry.CompatibleModules(inst.StabilityToleranceConfig, inst.VersionCriteria())
                                        .Where(m => !installedIdents.Contains(m.identifier))
@@ -403,15 +401,14 @@ namespace CKAN.GUI
                           .ToArray()
                 is { Length: > 0 } upgrades)
             {
-                var upgradeable = registry.CheckUpgradeable(instance,
-                                                            // Hold identifiers not chosen for upgrading
-                                                            registry.Installed(false)
-                                                                    .Select(kvp => kvp.Key)
-                                                                    .Except(upgrades.Select(ch => ch.Mod.identifier))
-                                                                    .ToHashSet(),
-                                                            allLabels.IgnoreMissingIdentifiers(instance)
-                                                                     .ToHashSet())
-                                          [true]
+                var upgradeable = registry.UpgradeableModules(instance,
+                                                              // Hold identifiers not chosen for upgrading
+                                                              registry.Installed(false)
+                                                                      .Select(kvp => kvp.Key)
+                                                                      .Except(upgrades.Select(ch => ch.Mod.identifier))
+                                                                      .ToHashSet(),
+                                                              allLabels.IgnoreMissingIdentifiers(instance)
+                                                                       .ToHashSet())
                                           .ToDictionary(m => m.identifier,
                                                         m => m);
                 foreach (var change in upgrades)
@@ -631,26 +628,25 @@ namespace CKAN.GUI
                                    List<ModChange>?          ChangeSet,
                                    DataGridViewRowCollection rows)
         {
-            var upgGroups = registry.CheckUpgradeable(inst,
+            var dlls = registry.InstalledDlls.ToList();
+            bool hasUpgradeable = false;
+            foreach (var (upgradeable, module) in registry.InstalledModulesByUpgradeability(
+                                                      inst,
                                                       allLabels.HeldIdentifiers(inst)
                                                                .ToHashSet(),
                                                       allLabels.IgnoreMissingIdentifiers(inst)
-                                                               .ToHashSet());
-            var dlls = registry.InstalledDlls.ToList();
-            foreach ((var upgradeable, var mods) in upgGroups)
+                                                               .ToHashSet()))
             {
-                foreach (var ident in mods.Select(m => m.identifier))
-                {
-                    dlls.Remove(ident);
-                    CheckRowUpgradeable(inst, ChangeSet, rows, ident, upgradeable);
-                }
+                hasUpgradeable = hasUpgradeable || upgradeable;
+                dlls.Remove(module.identifier);
+                CheckRowUpgradeable(inst, ChangeSet, rows, module.identifier, upgradeable);
             }
             // AD mods don't have CkanModules in the return value of CheckUpgradeable
             foreach (var ident in dlls)
             {
                 CheckRowUpgradeable(inst, ChangeSet, rows, ident, false);
             }
-            return upgGroups[true].Count > 0;
+            return hasUpgradeable;
         }
 
         private void CheckRowUpgradeable(GameInstance              inst,

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -329,6 +329,9 @@ Find the folder where your game is installed and choose one of these files:
   <data name="SettingsDialogRepoDeleteDelete" xml:space="preserve"><value>Delete</value></data>
   <data name="SettingsDialogRepoDeleteCancel" xml:space="preserve"><value>Cancel</value></data>
   <data name="SettingsDialogRepoAddDuplicateURL" xml:space="preserve"><value>Repository with URL already in list: {0}</value></data>
+  <data name="SettingsDialogRepoAddBlacklist" xml:space="preserve"><value>Not adding {0}:
+
+  {1}</value></data>
   <data name="AddAuthTokenTitle" xml:space="preserve"><value>Add Authentication Token</value></data>
   <data name="AddAuthTokenHost" xml:space="preserve"><value>Host:</value></data>
   <data name="AddAuthTokenToken" xml:space="preserve"><value>Token:</value></data>

--- a/Tests/Core/IO/ModuleInstallerTests.cs
+++ b/Tests/Core/IO/ModuleInstallerTests.cs
@@ -1068,6 +1068,7 @@ namespace Tests.Core.IO
                                                                                                   inst.KSP.VersionCriteria()))
                                                                              .OfType<CkanModule>()
                                                                              .ToArray(),
+                                                           registry.InstalledModules.Select(im => im.Module).ToArray(),
                                                            opts, registry, inst.KSP.Game, inst.KSP.VersionCriteria()));
             }
         }

--- a/Tests/Core/Registry/Registry.cs
+++ b/Tests/Core/Registry/Registry.cs
@@ -11,6 +11,7 @@ using Tests.Data;
 using CKAN;
 using CKAN.Configuration;
 using CKAN.Versioning;
+using Tests.Core.Relationships;
 
 namespace Tests.Core.Registry
 {
@@ -400,6 +401,77 @@ namespace Tests.Core.Registry
 
                 // Assert
                 Assert.IsFalse(has, "Upgrade allowed that would break another mod's dependency");
+            }
+        }
+
+        [TestCase(new string[] { },
+                  new string[] { },
+                  new string[] { }),
+         TestCase(new string[]
+                  {
+                      @"{
+                          ""identifier"": ""RasterPropMonitor"",
+                          ""version"":    ""2.0"",
+                          ""conflicts"":  [ { ""name"": ""MechJeb2"" } ]
+                      }",
+                      @"{
+                          ""identifier"": ""MechJeb2-dev"",
+                          ""version"":    ""2.0"",
+                          ""provides"":   [ ""MechJeb2"" ]
+                      }",
+                      @"{
+                          ""identifier"": ""MakingHistory-DLC"",
+                          ""version"":    ""2.0"",
+                          ""kind"":       ""dlc""
+                      }",
+                  },
+                  new string[]
+                  {
+                      @"{
+                          ""identifier"": ""RasterPropMonitor"",
+                          ""version"":    ""1.0""
+                      }",
+                      @"{
+                          ""identifier"": ""MechJeb2-dev"",
+                          ""version"":    ""1.0"",
+                          ""provides"":   [ ""MechJeb2"" ]
+                      }",
+                  },
+                  new string[] { "MechJeb2-dev 2.0" }),
+        ]
+        public void UpgradeableModules_RPMAndMechJeb2Dev_UpgradesMechJeb2Dev(
+                string[] availableModules,
+                string[] installedModules,
+                string[] expectedUpgradeable)
+        {
+            // Arrange
+            var user = new NullUser();
+            using (var gameInstWrapper = new DisposableKSP())
+            using (var repo = new TemporaryRepository(RelationshipResolverTests.MergeWithDefaults(availableModules)
+                                                                               .ToArray()))
+            using (var repoData = new TemporaryRepositoryData(user, repo.repo))
+            {
+                var registry = new CKAN.Registry(repoData.Manager, repo.repo);
+                registry.SetDlcs(new Dictionary<string, UnmanagedModuleVersion>()
+                                 {
+                                     {
+                                         "MakingHistory-DLC",
+                                         new UnmanagedModuleVersion("1.0")
+                                     },
+                                 });
+                foreach (var m in RelationshipResolverTests.MergeWithDefaults(installedModules)
+                                                           .Select(CkanModule.FromJson))
+                {
+                    registry.RegisterModule(m, Array.Empty<string>(), gameInstWrapper.KSP, false);
+                }
+
+                // Act
+                var upgradeable = registry.UpgradeableModules(gameInstWrapper.KSP,
+                                                              new HashSet<string>());
+
+                // Assert
+                CollectionAssert.AreEquivalent(expectedUpgradeable,
+                                               upgradeable.Select(m => m.ToString()));
             }
         }
 

--- a/Tests/GUI/Model/GUIMod.cs
+++ b/Tests/GUI/Model/GUIMod.cs
@@ -71,14 +71,13 @@ namespace Tests.GUI
                     var registry = new Registry(repoData.Manager, repo.repo);
 
                     registry.RegisterModule(old_version, new List<string>(), tidy.KSP, false);
-                    var upgradeableGroups = registry.CheckUpgradeable(tidy.KSP,
-                                                                      new HashSet<string>());
+                    var upgradeable = registry.UpgradeableModules(tidy.KSP, new HashSet<string>()).ToArray();
 
                     var mod = new GUIMod(old_version, repoData.Manager, registry,
                                          tidy.KSP.StabilityToleranceConfig, tidy.KSP, cache,
                                          null, false, false)
                     {
-                        HasUpdate = upgradeableGroups[true].Any(m => m.identifier == old_version.identifier),
+                        HasUpdate = upgradeable.Any(m => m.identifier == old_version.identifier),
                     };
                     Assert.True(mod.HasUpdate);
                 }

--- a/Tests/GUI/Model/GUIMod.cs
+++ b/Tests/GUI/Model/GUIMod.cs
@@ -64,9 +64,9 @@ namespace Tests.GUI
                 using (var repo = new TemporaryRepository(old_version.ToJson(),
                                                           new_version.ToJson()))
                 using (var repoData = new TemporaryRepositoryData(user, repo.repo))
-            using (var cacheDir = new TemporaryDirectory())
-            using (var cache    = new NetModuleCache(cacheDir))
-            {
+                using (var cacheDir = new TemporaryDirectory())
+                using (var cache    = new NetModuleCache(cacheDir))
+                {
                     var registry = new Registry(repoData.Manager, repo.repo);
 
                     registry.RegisterModule(old_version, new List<string>(), tidy.KSP, false);

--- a/Tests/GUI/Model/GUIMod.cs
+++ b/Tests/GUI/Model/GUIMod.cs
@@ -16,6 +16,7 @@ using CKAN.GUI;
 using CKAN.Versioning;
 
 using Tests.Core.Configuration;
+using Tests.Core.Relationships;
 using Tests.Data;
 
 namespace Tests.GUI
@@ -81,6 +82,38 @@ namespace Tests.GUI
                     };
                     Assert.True(mod.HasUpdate);
                 }
+            }
+        }
+
+        [Test]
+        public void DownloadSizeInstallSize_Metapackage_NSlashA()
+        {
+            // Arrange
+            var metapackJson = RelationshipResolverTests.MergeWithDefaults(
+                                   @"{
+                                       ""identifier"": ""MyModPack"",
+                                       ""version"":    ""1.0"",
+                                       ""kind"":       ""metapackage""
+                                   }");
+            var user = new NullUser();
+            using (var gameInstWrapper = new DisposableKSP())
+            using (var repo = new TemporaryRepository(metapackJson))
+            using (var repoData = new TemporaryRepositoryData(user, repo.repo))
+            using (var cacheDir = new TemporaryDirectory())
+            using (var cache    = new NetModuleCache(cacheDir))
+            {
+                var metapack = CkanModule.FromJson(metapackJson);
+
+                // Act
+                var gmod = new GUIMod(metapack, new RepositoryDataManager(),
+                                                new CKAN.Registry(repoData.Manager, repo.repo),
+                                                gameInstWrapper.KSP.StabilityToleranceConfig,
+                                                gameInstWrapper.KSP, cache, false, false, false);
+
+                // Assert
+                Assert.AreEqual("N/A", gmod.DownloadSize);
+                Assert.AreEqual("N/A", gmod.InstallSize);
+                Assert.AreEqual("1.0", gmod.Version);
             }
         }
 

--- a/Tests/GUI/Model/ModList.cs
+++ b/Tests/GUI/Model/ModList.cs
@@ -19,6 +19,7 @@ using CKAN;
 using CKAN.IO;
 using CKAN.GUI;
 using Tests.Core.Configuration;
+using Tests.Core.Relationships;
 using Tests.Data;
 
 namespace Tests.GUI
@@ -710,6 +711,64 @@ namespace Tests.GUI
                                                    "VirginKalactic-NodeToggle",
                                                },
                                                full.Item1.Select(ch => ch.Mod.identifier).Order());
+            }
+        }
+
+        [Test]
+        public void ComputeFullChangeSetFromUserChangeSet_WithAutoRemovable_Removes()
+        {
+            // Arrange
+            var installed = new string[]
+            {
+                @"{
+                    ""identifier"": ""Mod1""
+                }",
+                @"{
+                    ""identifier"": ""Mod2"",
+                    ""depends"":    [ { ""name"": ""Mod1"" } ]
+                }",
+                @"{
+                    ""identifier"": ""Mod3"",
+                    ""depends"":    [ { ""name"": ""Mod2"" } ]
+                }",
+            };
+            var user      = new NullUser();
+            var repo      = new Repository("test", "https://github.com/");
+            var guiConfig = new GUIConfiguration();
+            using (var inst     = new DisposableKSP())
+            using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
+            using (var repoData = new TemporaryRepositoryData(user))
+            using (var cacheDir = new TemporaryDirectory())
+            using (var cache    = new NetModuleCache(cacheDir))
+            {
+                var registry = new CKAN.Registry(repoData.Manager, repo);
+                foreach (var m in installed.Select(RelationshipResolverTests.MergeWithDefaults)
+                                           .Select(CkanModule.FromJson))
+                {
+                    registry.RegisterModule(m, Array.Empty<string>(), inst.KSP, true);
+                }
+                var labels  = ModuleLabelList.GetDefaultLabels();
+                var mods    = ModList.GetGUIMods(registry, repoData.Manager, inst.KSP, labels, cache, guiConfig)
+                                     .ToArray();
+                var modlist = new ModList(mods, inst.KSP,
+                                          labels, new ModuleTagList(),
+                                          guiConfig, graphics);
+
+                // Act
+                var changes = modlist.ComputeUserChangeSet(registry, inst.KSP, null, null);
+                var full    = ModList.ComputeFullChangeSetFromUserChangeSet(registry, changes,
+                                                                            config, inst.KSP);
+
+                // Assert
+                CollectionAssert.AreEquivalent(new string[]
+                                               {
+                                                   "Mod1",
+                                                   "Mod2",
+                                                   "Mod3",
+                                               },
+                                               full.Item1.Where(ch => ch.ChangeType == GUIModChangeType.Remove)
+                                                         .Select(ch => ch.Mod.identifier)
+                                                         .Order());
             }
         }
 


### PR DESCRIPTION
## Problems

- Discord user Hyperion\_21 reported that an old installed version of MechJeb2-dev wasn't being shown as upgradeable, even though selecting the latest version manually worked fine.
- If you had a lot of mods installed and unchecked the checkbox at the upper left to uninstall them all, CKAN could become unresponsive for a second or three.
- Since the Description column can contain long strings, #4591 added a tooltip so the user can easily read the full contents by hovering. However, if a mod is marked red due to a conflict, the conflict description overwrites the description contents tooltip.
- If a mod's download count is unknown (e.g., the mods from the Sol metadata repository from KSP-CKAN/CKAN-meta#3383), the grid displays it as 0, incorrectly suggesting there have been no downloads.
- If a mod's download size or install size is unknown, the grid displays it as "N/A", incorrectly suggesting that there is no download or install size.
- The "Supported by" section of the recommendations screen could show mods that conflict with your installed mods, even though trying to install them would result in an error.

## Causes

- The upgradeability logic from #4023 is somewhat limited; it only checks an installed mod's upgradeability _in the context of upgrading everything else_.
  In `Hyperion_21`'s case, both MechJeb2-dev and RasterPropMonitor had old versions installed, and RasterPropMonitor's latest version had a conflict with MechJeb, which is provided by all versions of MechJeb2-dev, so upgrading RasterPropMonitor wasn't allowed. However, that _potential_ update still ended up in the "context of upgrading everything else" against which MechJeb2-dev was checked, which blocked that mod's upgrade as well.
- When you choose to uninstall a mod, there are some checks for other mods to be uninstalled, which are unnecessary if you're already uninstalling everything.
- I didn't remember conflict tooltips existed during #4591.
- `RepositoryDataManager.GetDownloadCount` used `.OfType<int>().FirstOrDefault()` to handle null values, but the `default` of `int` is `0`, so the function could never return `null` even thought it was designed for that. But even without that, `GetValueOrDefault` _also_ returns `0` for a missing value when the dict's value type is `int`!
- `GUIMod.DownloadSize` and `GUIMod.InstallSize` were set to "N/A" if the underlying values were `0`
- `ModuleInstaller.CanInstall`, which is responsible for checking which supporting mods are installable, lacked a `toRemove` param to handle mods being removed. Instead, it decided to pretend that _all_ mods were being removed, so installed mods' conflicts would be ignored.

## Motivations

- A user recently used an LLM to generate and publicize a metadata repository containing lots of broken metadata, which caused problems for users (see Gameslinx/Parallax-Continued#123), which they reported to us on Discord.
  This rogue repository has since been deleted, but conditions are arguably ripe for this to happen again at some point.

## Changes

- Now the upgradeability logic is rewritten to generate sets of mods to upgrade using recursion. For each installed mod, it calls `HasUpdate` against the accumulated set of updates, and if it returns true, it first adds that update to the set and continues checking the rest of the mods. Then, regardless of what `HasUpdate` returned, it tries a group with the currently installed module instead, to catch cases where another mod prevents this one from updating. Each time it has a complete group of choices, it uses `RelationshipResolver` to make sure it's valid.
  Not only is this more correct, I think it may also be faster based on timings of test runs (it does incur fewer `HasUpdate` calls on average).
  A test is added to exercise Hyperion\_21's use case, which passes on the new code and fails on the old code.
- Now if you're uninstalling everything, we skip the additional checks for mods to uninstall, which will speed up that action.
- Now when a mod is conflicted, the description tooltip is not overwritten.
- Now `GetDownloadCount` uses `TryGetValue` to get the values and an explicit null check to avoid ever accidentally returning `default(int)`, so the grid cells will be blank instead of 0 for unknown counts.
- Now "N/A" only appears for the download and install sizes of metapackages; other mods with unknown sizes will have blank cells
- Now mods being removed are passed to a new `toRemove` param of `ModuleInstaller.CanInstall`, so the "Supported by" list will be more accurate.
- Now the blacklist info from KSP-CKAN/CKAN-meta#3411 is parsed into a new property of `RepositoryList` and used to display an error when the user tries to add a known-bad repo:
  <img width="1204" height="277" alt="image" src="https://github.com/user-attachments/assets/d12830df-96aa-41ec-b50f-bc9beb18f91d" />
