### PR TITLE
Optimize new upgradeability logic

### DIFF
--- a/Cmdline/Action/Install.cs
+++ b/Cmdline/Action/Install.cs
@@ -34,7 +34,8 @@ namespace CKAN.CmdLine
         /// </returns>
         public int RunCommand(CKAN.GameInstance instance, object raw_options)
         {
-            RegistryManager.Instance(instance, repoData).ScanUnmanagedFiles();
+            var regMgr = RegistryManager.Instance(instance, repoData, headless: user.Headless);
+            regMgr.ScanUnmanagedFiles();
 
             var options = raw_options as InstallOptions;
             if (options?.modules?.Count == 0 && options.ckan_files == null)
@@ -47,7 +48,6 @@ namespace CKAN.CmdLine
                 return Exit.BADOPT;
             }
 
-            var regMgr = RegistryManager.Instance(instance, repoData);
             List<CkanModule>? modules = null;
 
             if (options?.ckan_files != null)

--- a/Cmdline/Action/List.cs
+++ b/Cmdline/Action/List.cs
@@ -24,7 +24,7 @@ namespace CKAN.CmdLine
         {
             ListOptions options = (ListOptions) raw_options;
 
-            var regMgr   = RegistryManager.Instance(instance, repoData);
+            var regMgr   = RegistryManager.Instance(instance, repoData, headless: user.Headless);
             var registry = regMgr.registry;
 
             ExportFileType? exportFileType = null;

--- a/Cmdline/Action/Prompt.cs
+++ b/Cmdline/Action/Prompt.cs
@@ -188,7 +188,7 @@ namespace CKAN.CmdLine
         private string[] GetAvailIdentifiers(string prefix)
         {
             CKAN.GameInstance inst = MainClass.GetGameInstance(manager);
-            return RegistryManager.Instance(inst, repoData)
+            return RegistryManager.Instance(inst, repoData, headless: user.Headless)
                                   .registry
                                   .CompatibleModules(inst.StabilityToleranceConfig, inst.VersionCriteria())
                                   .Where(m => !m.IsDLC)
@@ -206,7 +206,7 @@ namespace CKAN.CmdLine
         private string[] GetInstIdentifiers(string prefix)
         {
             CKAN.GameInstance inst = MainClass.GetGameInstance(manager);
-            var registry = RegistryManager.Instance(inst, repoData).registry;
+            var registry = RegistryManager.Instance(inst, repoData, headless: user.Headless).registry;
             return registry.Installed(false, false)
                            .Keys
                            .Where(ident => ident.StartsWith(prefix, StringComparison.InvariantCultureIgnoreCase)

--- a/Cmdline/Action/Remove.cs
+++ b/Cmdline/Action/Remove.cs
@@ -35,7 +35,7 @@ namespace CKAN.CmdLine
         public int RunCommand(CKAN.GameInstance instance, object raw_options)
         {
             RemoveOptions options = (RemoveOptions) raw_options;
-            RegistryManager regMgr = RegistryManager.Instance(instance, repoData);
+            RegistryManager regMgr = RegistryManager.Instance(instance, repoData, headless: user.Headless);
 
             // Use one (or more!) regex to select the modules to remove
             if (options.regex)

--- a/Cmdline/Action/Show.cs
+++ b/Cmdline/Action/Show.cs
@@ -32,7 +32,7 @@ namespace CKAN.CmdLine
 
             int combined_exit_code = Exit.OK;
             // Check installed modules for an exact match.
-            var registry = RegistryManager.Instance(instance, repoData).registry;
+            var registry = RegistryManager.Instance(instance, repoData, headless: user.Headless).registry;
             foreach (string modName in options.modules)
             {
                 (InstalledModule?, CkanModule?) toShow = (null, null);

--- a/Cmdline/Action/Update.cs
+++ b/Cmdline/Action/Update.cs
@@ -79,7 +79,7 @@ namespace CKAN.CmdLine
                     if (options.list_changes)
                     {
                         // Get a list of compatible modules prior to the update.
-                        var registry = RegistryManager.Instance(instance, repoData).registry;
+                        var registry = RegistryManager.Instance(instance, repoData, headless: user.Headless).registry;
                         var crit     = instance.VersionCriteria();
                         var compatible_prior = registry.CompatibleModules(stabilityTolerance, crit).ToList();
                         UpdateRepositories(instance, options.NetUserAgent, options.force);
@@ -177,7 +177,7 @@ namespace CKAN.CmdLine
         /// <param name="repository">Repository to update. If null all repositories are used.</param>
         private void UpdateRepositories(CKAN.GameInstance instance, string? userAgent, bool force = false)
         {
-            var registry = RegistryManager.Instance(instance, repoData).registry;
+            var registry = RegistryManager.Instance(instance, repoData, headless: user.Headless).registry;
             var result = repoData.Update(registry.Repositories.Values.ToArray(),
                                          instance.Game, force,
                                          new NetAsyncDownloader(user, () => null, userAgent), user, userAgent);

--- a/Cmdline/Main.cs
+++ b/Cmdline/Main.cs
@@ -241,7 +241,7 @@ namespace CKAN.CmdLine
                                                    .RunCommand(GetGameInstance(manager), opts),
                     InstallOptions     opts => new Install(manager, repoData, user)
                                                    .RunCommand(GetGameInstance(manager), opts),
-                    ScanOptions        opts => Scan(GetGameInstance(manager), repoData),
+                    ScanOptions        opts => Scan(GetGameInstance(manager), repoData, user),
                     ListOptions        opts => new List(repoData, user, Console.OpenStandardOutput())
                                                    .RunCommand(GetGameInstance(manager), opts),
                     ShowOptions        opts => new Show(repoData, user)
@@ -331,9 +331,10 @@ namespace CKAN.CmdLine
         /// <param name="next_command">Changes the output message if set.</param>
         /// <returns>Exit.OK if instance is consistent, Exit.ERROR otherwise </returns>
         private static int Scan(CKAN.GameInstance     inst,
-                                RepositoryDataManager repoData)
+                                RepositoryDataManager repoData,
+                                IUser                 user)
         {
-            RegistryManager.Instance(inst, repoData).ScanUnmanagedFiles();
+            RegistryManager.Instance(inst, repoData, headless: user.Headless).ScanUnmanagedFiles();
             return Exit.OK;
         }
 

--- a/ConsoleUI/ModListScreen.cs
+++ b/ConsoleUI/ModListScreen.cs
@@ -498,7 +498,7 @@ namespace CKAN.ConsoleUI {
 
         private bool PlayGame(string commandLine)
         {
-            manager.CurrentInstance?.PlayGame(commandLine);
+            manager.CurrentInstance?.PlayGame(commandLine, this);
             return true;
         }
 

--- a/Core/GameInstance.cs
+++ b/Core/GameInstance.cs
@@ -32,11 +32,10 @@ namespace CKAN
         /// Returns a game instance object.
         /// Will initialise a CKAN instance in the game dir if it does not already exist.
         /// </summary>
-        public GameInstance(IGame game, string gameDir, string name, IUser? user)
+        public GameInstance(IGame game, string gameDir, string name)
         {
             Game = game;
             Name = name;
-            User = user ?? new NullUser();
             // Make sure our path is absolute and has normalised slashes.
             GameDir = CKANPathUtils.NormalizePath(Path.GetFullPath(gameDir));
             if (Platform.IsWindows)
@@ -79,8 +78,8 @@ namespace CKAN
 
             if (!Directory.Exists(CkanDir))
             {
-                User.RaiseMessage(Properties.Resources.GameInstanceSettingUp);
-                User.RaiseMessage(Properties.Resources.GameInstanceCreatingDir, CkanDir);
+                log.Debug(Properties.Resources.GameInstanceSettingUp);
+                log.DebugFormat(Properties.Resources.GameInstanceCreatingDir, CkanDir);
                 txFileMgr.CreateDirectory(CkanDir);
             }
 
@@ -88,7 +87,7 @@ namespace CKAN
 
             if (!Directory.Exists(InstallHistoryDir))
             {
-                User.RaiseMessage(Properties.Resources.GameInstanceCreatingDir, InstallHistoryDir);
+                log.DebugFormat(Properties.Resources.GameInstanceCreatingDir, InstallHistoryDir);
                 txFileMgr.CreateDirectory(InstallHistoryDir);
             }
             log.InfoFormat("Initialised {0}", Platform.FormatPath(CkanDir));
@@ -97,8 +96,6 @@ namespace CKAN
         #endregion
 
         #region Fields and Properties
-
-        public IUser User { get; private set; }
 
         public string Name { get; set; }
 
@@ -360,7 +357,7 @@ namespace CKAN
                    new string[] { "CKAN" });
 
         [ExcludeFromCodeCoverage]
-        public void PlayGame(string command, Action? onExit = null)
+        public void PlayGame(string command, IUser user, Action? onExit = null)
         {
             if (Game.AdjustCommandLine(command.Split(' '), Version())
                 //is [string binary, ..] and string[] split
@@ -399,7 +396,7 @@ namespace CKAN
                 }
                 catch (Exception exception)
                 {
-                    User.RaiseError(Properties.Resources.GameInstancePlayGameFailed, exception.Message);
+                    user.RaiseError(Properties.Resources.GameInstancePlayGameFailed, exception.Message);
                 }
             }
         }

--- a/Core/GameInstanceManager.cs
+++ b/Core/GameInstanceManager.cs
@@ -82,8 +82,7 @@ namespace CKAN
             switch (KnownGames.knownGames.Select(g => GameInstance.PortableDir(g)
                                                       is string p
                                                           ? new GameInstance(g, p,
-                                                                             Properties.Resources.GameInstanceManagerPortable,
-                                                                             User)
+                                                                             Properties.Resources.GameInstanceManagerPortable)
                                                           : null)
                                          .OfType<GameInstance>()
                                          .Where(i => i.Valid)
@@ -169,7 +168,7 @@ namespace CKAN
                                         .OfType<Tuple<string, DirectoryInfo>>()
                                         .Select(tuple => tuple.Item1 != null && g.GameInFolder(tuple.Item2)
                                                        ? new GameInstance(g, tuple.Item2.FullName,
-                                                                          tuple.Item1 ?? g.ShortName, User)
+                                                                          tuple.Item1 ?? g.ShortName)
                                                        : null)
                                         .OfType<GameInstance>())
                                   .Where(inst => inst.Valid)
@@ -228,7 +227,7 @@ namespace CKAN
         public GameInstance? AddInstance(string path, string name, IUser user)
         {
             var game = DetermineGame(new DirectoryInfo(path), user);
-            return game == null ? null : AddInstance(new GameInstance(game, path, name, user));
+            return game == null ? null : AddInstance(new GameInstance(game, path, name));
         }
 
         /// <summary>
@@ -302,7 +301,7 @@ namespace CKAN
                                     new string[] { "CKAN" });
 
             // Add the new instance to the config
-            return AddInstance(new GameInstance(existingInstance.Game, newPath, newName, User));
+            return AddInstance(new GameInstance(existingInstance.Game, newPath, newName));
         }
 
         /// <summary>
@@ -388,7 +387,7 @@ namespace CKAN
                 }
 
                 // Add the new instance to the config
-                GameInstance new_instance = new GameInstance(game, newPath, newName, User);
+                GameInstance new_instance = new GameInstance(game, newPath, newName);
                 AddInstance(new_instance);
                 transaction.Complete();
                 return new_instance;
@@ -518,8 +517,7 @@ namespace CKAN
             if (DetermineGame(di, User) is IGame game)
             {
                 var inst = new GameInstance(game, path,
-                                            Properties.Resources.GameInstanceByPathName,
-                                            User);
+                                            Properties.Resources.GameInstanceByPathName);
                 if (inst.Valid)
                 {
                     return inst;
@@ -573,7 +571,7 @@ namespace CKAN
                                ?? KnownGames.knownGames.First();
                     log.DebugFormat("Loading {0} from {1}", name, Platform.FormatPath(path));
                     // Add unconditionally, sort out invalid instances downstream
-                    instances.Add(name, new GameInstance(game, path, name, User));
+                    instances.Add(name, new GameInstance(game, path, name));
                 }
                 catch (Exception exc)
                 {

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -287,13 +287,33 @@ namespace CKAN
         private static IEnumerable<(bool upgradeable, CkanModule module)[]> FindUpgradeabilitySolutions(
                 this IRegistryQuerier                   querier,
                 GameInstance                            instance,
-                IReadOnlyCollection<string>             remainingIdents,
-                (bool upgradeable, CkanModule module)[] partialSolution,
+                IReadOnlyCollection<string>             startingIdents,
+                (bool upgradeable, CkanModule module)[] initialSolution,
                 HashSet<string>                         filters,
                 HashSet<string>                         heldIdents,
                 HashSet<string>?                        ignoreMissingIdents = null)
         {
-            if (remainingIdents.Count == 0)
+            // Find non-upgradeable mods so we can skip looping over them
+            var initialMods    = initialSolution.Select(tuple => tuple.module).ToArray();
+            var notUpgradeable = startingIdents.Where(ident => heldIdents.Contains(ident)
+                                                               || !querier.HasUpdate(ident,
+                                                                                     instance.StabilityToleranceConfig,
+                                                                                     instance, filters,
+                                                                                     !ignoreMissingIdents?.Contains(ident)
+                                                                                                         ?? true,
+                                                                                     out CkanModule? latest,
+                                                                                     initialMods))
+                                               .Select(querier.GetInstalledVersion)
+                                               .OfType<CkanModule>()
+                                               .ToArray();
+            var remainingIdents = startingIdents.Except(notUpgradeable.Select(m => m.identifier)).ToArray();
+            var partialSolution = initialSolution.Concat(notUpgradeable.Where(m => !m.IsDLC)
+                                                                       .Select(m => (upgradeable: false,
+                                                                                     module:      m)))
+                                                 .ToArray();
+            var partialMods     = partialSolution.Select(tuple => tuple.module).ToArray();
+
+            if (remainingIdents.Length == 0)
             {
                 // We are a leaf node, return whatever we received if it is a valid solution
                 if (partialSolution.All(tuple => !tuple.upgradeable)
@@ -316,12 +336,12 @@ namespace CKAN
             {
                 var otherIdents = remainingIdents.Where(i => i != ident)
                                                  .ToArray();
+                // Have to check HasUpdate again to account for the additions to partialSolution
                 if (!heldIdents.Contains(ident)
                     && querier.HasUpdate(ident, instance.StabilityToleranceConfig, instance, filters,
                                          !ignoreMissingIdents?.Contains(ident) ?? true,
                                          out CkanModule? latest,
-                                         partialSolution.Select(tuple => tuple.module)
-                                                        .ToArray()))
+                                         partialMods))
                 {
                     // Upgrading this mod is allowed so far, use it to check the remaining mods
                     foreach (var solution in querier.FindUpgradeabilitySolutions(

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -53,7 +53,8 @@ namespace CKAN
         private RegistryManager(string                          path,
                                 GameInstance                    inst,
                                 RepositoryDataManager           repoData,
-                                IReadOnlyCollection<Repository> initialRepositories)
+                                IReadOnlyCollection<Repository> initialRepositories,
+                                bool                            headless = false)
         {
             gameInstance = inst;
 
@@ -89,7 +90,7 @@ namespace CKAN
             {
                 // Only log an error for this if user-interactive,
                 // automated tools do not care that no one picked a Scatterer config
-                if (gameInstance.User.Headless)
+                if (headless)
                 {
                     log.InfoFormat("Loaded registry with inconsistencies:\r\n\r\n{0}", kraken.Message);
                 }
@@ -263,14 +264,16 @@ namespace CKAN
         /// </summary>
         public static RegistryManager Instance(GameInstance                     inst,
                                                RepositoryDataManager            repoData,
-                                               IReadOnlyCollection<Repository>? repositories = null)
+                                               IReadOnlyCollection<Repository>? repositories = null,
+                                               bool                             headless = false)
         {
             string directory = inst.CkanDir;
             if (!registryCache.ContainsKey(directory))
             {
                 log.DebugFormat("Preparing to load registry at {0}", Platform.FormatPath(directory));
                 registryCache[directory] = new RegistryManager(directory, inst, repoData,
-                                                               repositories ?? Array.Empty<Repository>());
+                                                               repositories ?? Array.Empty<Repository>(),
+                                                               headless);
             }
 
             return registryCache[directory];

--- a/GUI/Controls/ManageMods.Designer.cs
+++ b/GUI/Controls/ManageMods.Designer.cs
@@ -382,7 +382,6 @@ namespace CKAN.GUI
             //
             // Installed
             //
-            this.Installed.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
             this.Installed.Name = "Installed";
             this.Installed.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.Installed.Frozen = true;
@@ -393,7 +392,6 @@ namespace CKAN.GUI
             //
             // AutoInstalled
             //
-            this.AutoInstalled.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
             this.AutoInstalled.Name = "AutoInstalled";
             this.AutoInstalled.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.AutoInstalled.Frozen = true;
@@ -404,7 +402,6 @@ namespace CKAN.GUI
             //
             // UpdateCol
             //
-            this.UpdateCol.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
             this.UpdateCol.Name = "UpdateCol";
             this.UpdateCol.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.UpdateCol.Frozen = true;
@@ -415,7 +412,6 @@ namespace CKAN.GUI
             //
             // ReplaceCol
             //
-            this.ModName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
             this.ReplaceCol.Name = "ReplaceCol";
             this.ReplaceCol.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.ReplaceCol.Frozen = true;
@@ -426,16 +422,15 @@ namespace CKAN.GUI
             //
             // ModName
             //
-            this.ModName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.ModName.Name = "ModName";
             this.ModName.ReadOnly = true;
             this.ModName.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            this.ModName.MinimumWidth = 250;
+            this.ModName.MinimumWidth = 320;
             resources.ApplyResources(this.ModName, "ModName");
             //
             // Author
             //
-            this.Author.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.Author.FillWeight = 50;
             this.Author.Name = "Author";
             this.Author.ReadOnly = true;
             this.Author.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
@@ -444,7 +439,6 @@ namespace CKAN.GUI
             //
             // InstalledVersion
             //
-            this.InstalledVersion.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCellsExceptHeader;
             this.InstalledVersion.Name = "InstalledVersion";
             this.InstalledVersion.ReadOnly = true;
             this.InstalledVersion.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
@@ -453,7 +447,7 @@ namespace CKAN.GUI
             //
             // LatestVersion
             //
-            this.LatestVersion.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.LatestVersion.FillWeight = 25;
             this.LatestVersion.Name = "LatestVersion";
             this.LatestVersion.ReadOnly = true;
             this.LatestVersion.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
@@ -462,7 +456,6 @@ namespace CKAN.GUI
             //
             // GameCompatibility
             //
-            this.GameCompatibility.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCellsExceptHeader;
             this.GameCompatibility.Name = "GameCompatibility";
             this.GameCompatibility.ReadOnly = true;
             this.GameCompatibility.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
@@ -471,7 +464,6 @@ namespace CKAN.GUI
             //
             // DownloadSize
             //
-            this.DownloadSize.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCellsExceptHeader;
             this.DownloadSize.Name = "DownloadSize";
             this.DownloadSize.ReadOnly = true;
             this.DownloadSize.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
@@ -480,7 +472,6 @@ namespace CKAN.GUI
             //
             // InstallSize
             //
-            this.InstallSize.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCellsExceptHeader;
             this.InstallSize.Name = "InstallSize";
             this.InstallSize.ReadOnly = true;
             this.InstallSize.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
@@ -489,7 +480,6 @@ namespace CKAN.GUI
             //
             // ReleaseDate
             //
-            this.ReleaseDate.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCellsExceptHeader;
             this.ReleaseDate.Name = "ReleaseDate";
             this.ReleaseDate.ReadOnly = true;
             this.ReleaseDate.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
@@ -498,7 +488,6 @@ namespace CKAN.GUI
             //
             // InstallDate
             //
-            this.InstallDate.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCellsExceptHeader;
             this.InstallDate.Name = "InstallDate";
             this.InstallDate.ReadOnly = true;
             this.InstallDate.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
@@ -507,7 +496,6 @@ namespace CKAN.GUI
             //
             // DownloadCount
             //
-            this.DownloadCount.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCellsExceptHeader;
             this.DownloadCount.Name = "DownloadCount";
             this.DownloadCount.ReadOnly = true;
             this.DownloadCount.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
@@ -517,7 +505,6 @@ namespace CKAN.GUI
             //
             // Description
             //
-            this.Description.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.Description.Name = "Description";
             this.Description.ReadOnly = true;
             this.Description.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1329,14 +1329,14 @@ namespace CKAN.GUI
             if (freezeChangeSet)
             {
                 // Already frozen by some outer block, let it handle the cleanup
-                action?.Invoke();
+                action.Invoke();
             }
             else
             {
                 freezeChangeSet = true;
                 try
                 {
-                    action?.Invoke();
+                    action.Invoke();
                 }
                 finally
                 {

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -34,7 +34,10 @@ namespace CKAN.GUI
             {
                 ModGrid.BorderStyle = BorderStyle.None;
             }
-            uninstallingFont = new Font(ModGrid.Font, FontStyle.Strikeout);
+            uninstallingStyle = new DataGridViewCellStyle()
+            {
+                Font = new Font(ModGrid.Font, FontStyle.Strikeout),
+            };
 
             ToolTip.SetToolTip(InstallAllCheckbox, Properties.Resources.ManageModsInstallAllCheckboxTooltip);
             ToolTip.ScaleFonts();
@@ -103,7 +106,7 @@ namespace CKAN.GUI
         private DateTime lastSearchTime;
         private string? lastSearchKey;
         private readonly NavigationHistory<GUIMod> navHistory;
-        private readonly Font uninstallingFont;
+        private readonly DataGridViewCellStyle uninstallingStyle;
 
         private List<ModChange>?            currentChangeSet;
         private Dictionary<GUIMod, string>? conflicts;
@@ -213,12 +216,12 @@ namespace CKAN.GUI
                         if (removing.Contains(ident))
                         {
                             // Set strikeout font for rows being uninstalled
-                            row.DefaultCellStyle.Font = uninstallingFont;
+                            row.DefaultCellStyle = uninstallingStyle;
                         }
-                        else if (row.DefaultCellStyle.Font != null)
+                        else if (row.DefaultCellStyle != null)
                         {
                             // Clear strikeout font for rows not being uninstalled
-                            row.DefaultCellStyle.Font = ModGrid.DefaultCellStyle.Font;
+                            row.DefaultCellStyle = null;
                         }
                     }
                 }

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1477,6 +1477,18 @@ namespace CKAN.GUI
         private void ModGrid_Resize(object? sender, EventArgs? e)
         {
             InstallAllCheckbox.Top = ModGrid.Top - InstallAllCheckbox.Height;
+
+            // Expand/contract large columns to use the available space efficiently
+            ModName.AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill;
+            Author.AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill;
+            LatestVersion.AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill;
+            Description.AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill;
+
+            // Now make them resizable again
+            ModName.AutoSizeMode = DataGridViewAutoSizeColumnMode.NotSet;
+            Author.AutoSizeMode = DataGridViewAutoSizeColumnMode.NotSet;
+            LatestVersion.AutoSizeMode = DataGridViewAutoSizeColumnMode.NotSet;
+            Description.AutoSizeMode = DataGridViewAutoSizeColumnMode.NotSet;
         }
 
         private void reinstallToolStripMenuItem_Click(object? sender, EventArgs? e)
@@ -1738,6 +1750,15 @@ namespace CKAN.GUI
             });
 
             UpdateFilters();
+
+            // Fit small columns to their contents at load
+            ModGrid.AutoResizeColumn(InstalledVersion.Index,  DataGridViewAutoSizeColumnMode.AllCellsExceptHeader);
+            ModGrid.AutoResizeColumn(GameCompatibility.Index, DataGridViewAutoSizeColumnMode.AllCellsExceptHeader);
+            ModGrid.AutoResizeColumn(DownloadSize.Index,      DataGridViewAutoSizeColumnMode.AllCellsExceptHeader);
+            ModGrid.AutoResizeColumn(InstallSize.Index,       DataGridViewAutoSizeColumnMode.AllCellsExceptHeader);
+            ModGrid.AutoResizeColumn(ReleaseDate.Index,       DataGridViewAutoSizeColumnMode.AllCellsExceptHeader);
+            ModGrid.AutoResizeColumn(InstallDate.Index,       DataGridViewAutoSizeColumnMode.AllCellsExceptHeader);
+            ModGrid.AutoResizeColumn(DownloadCount.Index,     DataGridViewAutoSizeColumnMode.AllCellsExceptHeader);
 
             // Hide update and replacement columns if not needed.
             // Write it to the configuration, else they are hidden again after a filter change.

--- a/GUI/Dialogs/CloneGameInstanceDialog.cs
+++ b/GUI/Dialogs/CloneGameInstanceDialog.cs
@@ -158,7 +158,7 @@ namespace CKAN.GUI
                                           ? instFromBox
                                           : manager.DetermineGame(new DirectoryInfo(existingPath), user) is IGame sourceGame
                                               ? new GameInstance(sourceGame, existingPath,
-                                                                 "irrelevant", user)
+                                                                 "irrelevant")
                                               : null;
                 if (instanceToClone == null)
                 {

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -998,6 +998,7 @@ namespace CKAN.GUI
                 }
 
                 CurrentInstance.PlayGame(command,
+                                         currentUser,
                                          () =>
                                          {
                                              ManageMods.OnGameExit();

--- a/Tests/Core/GameInstance.cs
+++ b/Tests/Core/GameInstance.cs
@@ -25,7 +25,7 @@ namespace Tests.Core
             ksp_dir = TestData.NewTempDir();
             nullUser = new NullUser();
             Utilities.CopyDirectory(TestData.good_ksp_dir(), ksp_dir, Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>());
-            ksp = new GameInstance(new KerbalSpaceProgram(), ksp_dir, "test", nullUser);
+            ksp = new GameInstance(new KerbalSpaceProgram(), ksp_dir, "test");
         }
 
         [TearDown]
@@ -121,7 +121,7 @@ namespace Tests.Core
             File.WriteAllText(jsonpath, compatible_ksp_versions_json);
 
             // Act
-            GameInstance my_ksp = new GameInstance(new KerbalSpaceProgram(), gamedir, "missing-ver-test", nullUser);
+            GameInstance my_ksp = new GameInstance(new KerbalSpaceProgram(), gamedir, "missing-ver-test");
 
             // Assert
             Assert.IsFalse(my_ksp.Valid);
@@ -155,7 +155,7 @@ namespace Tests.Core
             // Act & Assert
             Assert.DoesNotThrow(() =>
             {
-                GameInstance my_ksp = new GameInstance(new KerbalSpaceProgram(), gamedir, "null-compat-ver-test", nullUser);
+                GameInstance my_ksp = new GameInstance(new KerbalSpaceProgram(), gamedir, "null-compat-ver-test");
             });
 
             Directory.Delete(gamedir, true);

--- a/Tests/Core/GameInstanceManager.cs
+++ b/Tests/Core/GameInstanceManager.cs
@@ -137,7 +137,7 @@ namespace Tests.Core
             {
                 var badKSP = new GameInstance(new KerbalSpaceProgram(),
                                               TestData.bad_ksp_dirs().First(),
-                                              "badDir", new NullUser());
+                                              "badDir");
 
                 Assert.Throws<NotGameDirKraken>(() =>
                     manager?.CloneInstance(badKSP, badName, tempdir));

--- a/Tests/Data/DisposableKSP.cs
+++ b/Tests/Data/DisposableKSP.cs
@@ -30,8 +30,7 @@ namespace Tests.Data
                                     Array.Empty<string>(),
                                     Array.Empty<string>(),
                                     Array.Empty<string>());
-            KSP = new GameInstance(game, _disposableDir,
-                                   name, new NullUser());
+            KSP = new GameInstance(game, _disposableDir, name);
         }
 
         public DisposableKSP(string registryFile)

--- a/Tests/Data/RandomModuleGenerator.cs
+++ b/Tests/Data/RandomModuleGenerator.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+using CKAN;
+using CKAN.Versioning;
+
+namespace Tests.Data
+{
+    public class RandomModuleGenerator
+    {
+        public Random Generator { get; set; }
+
+        public RandomModuleGenerator(Random generator)
+        {
+            Generator = generator;
+        }
+
+        public CkanModule GenerateRandomModule(
+            GameVersion?                  ksp_version = null,
+            List<RelationshipDescriptor>? conflicts   = null,
+            List<RelationshipDescriptor>? depends     = null,
+            List<RelationshipDescriptor>? recommends  = null,
+            List<RelationshipDescriptor>? suggests    = null,
+            List<string>?                 provides    = null,
+            string?                       identifier  = null,
+            ModuleVersion?                version     = null)
+            => new CkanModule(new ModuleVersion(1.ToString(CultureInfo.InvariantCulture)),
+                              identifier ?? Generator.Next().ToString(CultureInfo.InvariantCulture),
+                              Generator.Next().ToString(CultureInfo.InvariantCulture),
+                              Generator.Next().ToString(CultureInfo.InvariantCulture),
+                              "",
+                              new List<string> { Generator.Next().ToString(CultureInfo.InvariantCulture) },
+                              new List<License> { License.UnknownLicense },
+                              version ?? new ModuleVersion(Generator.Next().ToString(CultureInfo.InvariantCulture)),
+                              new List<Uri> { new Uri("http://github.com/") })
+            {
+                ksp_version = ksp_version,
+                conflicts   = conflicts,
+                depends     = depends,
+                recommends  = recommends,
+                suggests    = suggests,
+                provides    = provides,
+            };
+    }
+}

--- a/Tests/Data/TestData.cs
+++ b/Tests/Data/TestData.cs
@@ -1,13 +1,11 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Reflection;
 
 using CKAN;
 using CKAN.Extensions;
-using CKAN.Versioning;
 
 namespace Tests.Data
 {
@@ -989,42 +987,5 @@ namespace Tests.Data
                                     ""install_to"": ""GameData/ModuleManager"" } ]
             }",
         };
-    }
-
-    public class RandomModuleGenerator
-    {
-        public Random Generator { get; set; }
-
-        public RandomModuleGenerator(Random generator)
-        {
-            Generator = generator;
-        }
-
-        public CkanModule GenerateRandomModule(
-            GameVersion?                  ksp_version = null,
-            List<RelationshipDescriptor>? conflicts   = null,
-            List<RelationshipDescriptor>? depends     = null,
-            List<RelationshipDescriptor>? recommends  = null,
-            List<RelationshipDescriptor>? suggests    = null,
-            List<string>?                 provides    = null,
-            string?                       identifier  = null,
-            ModuleVersion?                version     = null)
-            => new CkanModule(new ModuleVersion(1.ToString(CultureInfo.InvariantCulture)),
-                              identifier ?? Generator.Next().ToString(CultureInfo.InvariantCulture),
-                              Generator.Next().ToString(CultureInfo.InvariantCulture),
-                              Generator.Next().ToString(CultureInfo.InvariantCulture),
-                              "",
-                              new List<string> { Generator.Next().ToString(CultureInfo.InvariantCulture) },
-                              new List<License> { License.UnknownLicense },
-                              version ?? new ModuleVersion(Generator.Next().ToString(CultureInfo.InvariantCulture)),
-                              new List<Uri> { new Uri("http://github.com/") })
-            {
-                ksp_version = ksp_version,
-                conflicts   = conflicts,
-                depends     = depends,
-                recommends  = recommends,
-                suggests    = suggests,
-                provides    = provides,
-            };
     }
 }


### PR DESCRIPTION
## Problems

- A user reported that trying to run the game via Steam throws an exception:
  ```
  System.IO.IOException: The handle is invalid.
     at System.ConsolePal.WindowsConsoleStream.Write(ReadOnlySpan`1 buffer)
     at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder)
     at System.IO.StreamWriter.WriteFormatHelper(String format, ReadOnlySpan`1 args, Boolean appendNewLine)
     at System.IO.StreamWriter.WriteLine(String format, Object[] arg)
     at System.IO.TextWriter.SyncTextWriter.WriteLine(String format, Object[] arg)
     at CKAN.CmdLine.ConsoleUser.RaiseError(String message, Object[] args)
     at CKAN.GameInstance.PlayGame(String command, Action onExit)
     at CKAN.GUI.Main.LaunchGame(String command)
     at CKAN.GUI.ManageMods.LaunchGameToolStripMenuItem_Click(Object sender, EventArgs e)
     at System.Windows.Forms.ToolStripMenuItem.OnClick(EventArgs e)
     at System.Windows.Forms.ToolStripItem.HandleClick(EventArgs e)
     at System.Windows.Forms.ToolStripItem.HandleMouseUp(MouseEventArgs e)
     at System.Windows.Forms.ToolStrip.OnMouseUp(MouseEventArgs mea)
     at System.Windows.Forms.ToolStripDropDown.OnMouseUp(MouseEventArgs mea)
     at System.Windows.Forms.Control.WmMouseUp(Message& m, MouseButtons button, Int32 clicks)
     at System.Windows.Forms.Control.WndProc(Message& m)
     at System.Windows.Forms.ToolStrip.WndProc(Message& m)
     at System.Windows.Forms.NativeWindow.Callback(HWND hWnd, UInt32 msg, WPARAM wparam, LPARAM lparam)
  ```
- Even after #4669, the uninstall-all checkbox is still slow if you have a hundred mods installed.
- The mod name column can't be resized by the user, other than by making the window wider.
- If you have a lot of mods installed, CKAN might get stuck after "Loading installed modules...".
  Reported by Discord user sol parsons (but I hit it myself shortly thereafter anyway).

## Causes

- `GameInstance` retains its own `IUser` reference, which it uses only to raise some messages in its constructor and report errors in `PlayGame`. Depending on how the game instance object is instantiated, this object might be a `ConsoleUser`, which outputs via `Console.WriteLine`. The handle to standard output becomes invalid when GUI closes the console, so `PlayGame` errors won't be reported correctly.
- The slow part turns out to be... the ~~strikeout~~ font for mods being uninstalled! Apparently changing the font makes the grid think the cell width might change, even when the font with is identical, so it recalculates the width of the whole column. _Once per row for which we change the font._ 
  The `DataGridView`'s performance is so tricky that Microsoft has a best practices page for it:
  <https://learn.microsoft.com/en-us/dotnet/desktop/winforms/controls/best-practices-for-scaling-the-windows-forms-datagridview-control?view=netframeworkdesktop-4.8>
- During #4591, I noticed that maximizing the window on a big monitor would leave a lot of horizontal space unused to the side of the mod list, so I set the columns' `AutoSizeMode` properties so the columns with long strings would get wider automatically in that case. And I thought it would be nice to also automatically fit the width of the narrower columns to their contents. However, these changes were not very well-received, because if `AutoSizeMode` is `Fill`, as it currently is for the mod name column, the user can't resize the column manually.
- The new upgradeability logic from #4669 can run a very long time if you have a mod with a potential upgrade that's forbidden by another installed mod, depending on the (random) ordering of the mods in `Registry.Installed(false).Keys`. Other times it's fast.
  Specifically, if the mod with the forbidden upgrade occurs before the mod that blocks it, this can result in a great many `RelationshipResolver` checks to find out it's forbidden, over and over as permutations of the remaining mods are iterated over.

## Changes

- Now `GameInstance.User` is removed, the messages in the constructor are replaced with log debug messages, and `PlayGame` now accepts an `IUser` parameter which will be guaranteed appropriate and ensure that the failed launch messages will be displayed properly.
  This reference was also used by `RegistryManager` to check whether the `Headless` command line flag, which now is replaced by a new parameter to `RegistryManager.Instance`.
  Fixes #4670.
- Now instead of setting `row.DefaultCellStyle.Font` to `uninstallingFont`, we set `row.DefaultCellStyle` to `uninstallingStyle`, since the best practices document says it's better.
- Now `AutoSizeMode` is no longer set by default for any column, so they're resizable by default.
  This speeds up the auto-uninstall checkbox substantially because setting the font will no longer cause the column auto-sizing logic to trigger.
  To retain the benefits of auto-sizing narrow columns, we now do a one-time auto-size operation after we finish loading the grid's data, after which the user can still make changes (but probably won't need to).
  To retain the benefits of auto-sizing the wide columns, we now temporarily set their `AutoSizeMode` to `Fill` and then back to `NotSet` in the grid's `Resize` event handler, which makes them automatically enlarge or shrink when the window is resized while still allowing the user to make manual adjustments (but they probably won't need to).
  Fixes #4650.
- Now at each level of recursion, we fully partition the remaining mods based on whether they can be upgraded with the context we've accumulated so far. Any mods that can't be upgraded are immediately put into the final list of mods as non-upgraded, so they won't be the subject of their own levels of recursion. This also ensures that they will be handled _before_ any mods for which they block upgrades, further reducing work done.
