### PR TITLE
Support Windows text scaling setting on net10

### DIFF
--- a/Core/Extensions/EnumerableExtensions.cs
+++ b/Core/Extensions/EnumerableExtensions.cs
@@ -231,8 +231,6 @@ namespace CKAN.Extensions
             {
                 result = func(result, item);
                 yield return result;
-
-
             }
         }
 

--- a/Core/Games/KerbalSpaceProgram.cs
+++ b/Core/Games/KerbalSpaceProgram.cs
@@ -101,17 +101,17 @@ namespace CKAN.Games.KerbalSpaceProgram
         /// Checks the path against a list of reserved game directories
         /// </summary>
         /// <param name="inst">Game instance we're checking</param>
-        /// <param name="path">Path to check</param>
+        /// <param name="absPath">Absolute path to check</param>
         /// <returns>True if reserved, false otherwise</returns>
-        public bool IsReservedDirectory(GameInstance inst, string path)
-            => path == inst.GameDir || path == inst.CkanDir
-            || path == PrimaryModDirectory(inst)
-            || path == Missions(inst)
-            || path == Scenarios(inst) || path == Tutorial(inst)
-            || path == Ships(inst)     || path == ShipsThumbs(inst)
-            || path == ShipsVab(inst)  || path == ShipsThumbsVAB(inst)
-            || path == ShipsSph(inst)  || path == ShipsThumbsSPH(inst)
-            || path == ShipsScript(inst);
+        public bool IsReservedDirectory(GameInstance inst, string absPath)
+            => absPath == inst.GameDir || absPath == inst.CkanDir
+            || absPath == PrimaryModDirectory(inst)
+            || absPath == Missions(inst)
+            || absPath == Scenarios(inst) || absPath == Tutorial(inst)
+            || absPath == Ships(inst)     || absPath == ShipsThumbs(inst)
+            || absPath == ShipsVab(inst)  || absPath == ShipsThumbsVAB(inst)
+            || absPath == ShipsSph(inst)  || absPath == ShipsThumbsSPH(inst)
+            || absPath == ShipsScript(inst);
 
         public bool AllowInstallationIn(string name, [NotNullWhen(true)] out string? path)
             => allowedFolders.TryGetValue(name, out path);

--- a/Core/IO/ModuleInstaller.cs
+++ b/Core/IO/ModuleInstaller.cs
@@ -1007,19 +1007,20 @@ namespace CKAN.IO
                 // before parents. GH #78.
                 foreach (string directory in directoriesToDelete.OrderByDescending(dir => dir.Length))
                 {
+                    var relPath = instance.ToRelativeGameDir(directory);
                     log.DebugFormat("Checking {0}...", directory);
                     // It is bad if any of this directories gets removed
                     // So we protect them
                     // A few string comparisons will be cheaper than hitting the disk, so do this first
-                    if (instance.Game.IsReservedDirectory(instance, directory))
+                    if (instance.Game.IsReservedDirectory(instance, directory)
+                        || instance.Game.StockFolders.Contains(relPath))
                     {
                         log.DebugFormat("Directory {0} is reserved, skipping", directory);
                         continue;
                     }
 
                     // See what's left in this folder and what we can do about it
-                    GroupFilesByRemovable(instance.ToRelativeGameDir(directory),
-                                          registry, modFiles, instance.Game,
+                    GroupFilesByRemovable(relPath, registry, modFiles, instance.Game,
                                           (Directory.Exists(directory)
                                               ? Directory.EnumerateFileSystemEntries(directory, "*", SearchOption.AllDirectories)
                                               : Enumerable.Empty<string>())
@@ -1129,53 +1130,47 @@ namespace CKAN.IO
         /// </summary>
         /// <param name="directories">The collection of directory path strings to examine</param>
         public HashSet<string> AddParentDirectories(HashSet<string> directories)
-        {
-            var gameDir = CKANPathUtils.NormalizePath(instance.GameDir);
-            return directories
-                .Where(dir => !string.IsNullOrWhiteSpace(dir))
-                // Normalize all paths before deduplicate
-                .Select(CKANPathUtils.NormalizePath)
-                // Remove any duplicate paths
-                .Distinct()
-                .SelectMany(dir =>
-                {
-                    var results = new HashSet<string>(Platform.PathComparer);
-                    // Adding in the DirectorySeparatorChar fixes attempts on Windows
-                    // to parse "X:" which resolves to Environment.CurrentDirectory
-                    var dirInfo = new DirectoryInfo(
-                        dir.EndsWith("/") ? dir : dir + Path.DirectorySeparatorChar);
+            => directories.Where(dir => dir is { Length: > 0 })
+                          // Normalize all paths before deduplicate
+                          .Select(CKANPathUtils.NormalizePath)
+                          // Remove any duplicate paths
+                          .Distinct()
+                          .SelectMany(dir =>
+                          {
+                              var results = new HashSet<string>(Platform.PathComparer);
+                              // Adding in the DirectorySeparatorChar fixes attempts on Windows
+                              // to parse "X:" which resolves to Environment.CurrentDirectory
+                              var dirInfo = new DirectoryInfo(
+                                  dir.EndsWith("/") ? dir : dir + Path.DirectorySeparatorChar);
 
-                    // If this is a parentless directory (Windows)
-                    // or if the Root equals the current directory (Mono)
-                    if (dirInfo.Parent == null || dirInfo.Root == dirInfo)
-                    {
-                        return results;
-                    }
+                              // If this is a parentless directory (Windows)
+                              // or if the Root equals the current directory (Mono)
+                              if (dirInfo.Parent == null || dirInfo.Root == dirInfo)
+                              {
+                                  return results;
+                              }
 
-                    if (!dir.StartsWith(gameDir, Platform.PathComparison))
-                    {
-                        dir = CKANPathUtils.ToAbsolute(dir, gameDir);
-                    }
+                              if (!dir.StartsWith(instance.GameDir, Platform.PathComparison))
+                              {
+                                  dir = CKANPathUtils.ToAbsolute(dir, instance.GameDir);
+                              }
 
-                    // Remove the system paths, leaving the path under the instance directory
-                    var relativeHead = CKANPathUtils.ToRelative(dir, gameDir);
-                    // Don't try to remove GameRoot
-                    if (!string.IsNullOrEmpty(relativeHead))
-                    {
-                        var pathArray = relativeHead.Split('/');
-                        var builtPath = "";
-                        foreach (var path in pathArray)
-                        {
-                            builtPath += path + '/';
-                            results.Add(CKANPathUtils.ToAbsolute(builtPath, gameDir));
-                        }
-                    }
-
-                    return results;
-                })
-                .Where(dir => !instance.Game.IsReservedDirectory(instance, dir))
-                .ToHashSet();
-        }
+                              for (var builtPath = CKANPathUtils.ToRelative(dir, instance.GameDir);
+                                   // Don't try to remove GameRoot
+                                   builtPath is { Length: > 0 };
+                                   builtPath = Path.GetDirectoryName(builtPath))
+                              {
+                                  if (instance.Game.StockFolders.Contains(builtPath))
+                                  {
+                                      // Can't delete this, no point in checking parent either
+                                      break;
+                                  }
+                                  results.Add(CKANPathUtils.ToAbsolute(builtPath, instance.GameDir));
+                              }
+                              return results;
+                          })
+                          .Where(dir => !instance.Game.IsReservedDirectory(instance, dir))
+                          .ToHashSet();
 
         #endregion
 

--- a/Core/Registry/InstalledModule.cs
+++ b/Core/Registry/InstalledModule.cs
@@ -5,8 +5,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Runtime.Serialization;
 
-using CKAN.IO;
 using Newtonsoft.Json;
+
+using CKAN.IO;
 
 namespace CKAN
 {
@@ -70,7 +71,7 @@ namespace CKAN
 
         public InstalledModule(GameInstance? ksp, CkanModule module, IEnumerable<string> relative_files, bool autoInstalled)
         {
-            install_time = DateTime.Now;
+            install_time = DateTime.UtcNow;
             source_module = module;
             // We need case insensitive path matching on Windows
             installed_files = new Dictionary<string, InstalledModuleFile>(Platform.PathComparer);

--- a/Core/Registry/RegistryManager.cs
+++ b/Core/Registry/RegistryManager.cs
@@ -385,7 +385,10 @@ namespace CKAN
                 writer.Formatting = Formatting.Indented;
                 writer.Indentation = 0;
 
-                JsonSerializer serializer = new JsonSerializer();
+                JsonSerializer serializer = new JsonSerializer()
+                {
+                    DateTimeZoneHandling = DateTimeZoneHandling.Utc,
+                };
                 serializer.Serialize(writer, registry);
             }
 

--- a/Core/Repositories/AvailableModule.cs
+++ b/Core/Repositories/AvailableModule.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Diagnostics.CodeAnalysis;
 
 using log4net;
 using Newtonsoft.Json;
@@ -186,6 +187,7 @@ namespace CKAN
         /// <returns>
         /// Nicely formatted JSON string containing metadata for all of this mod's available versions
         /// </returns>
+        [ExcludeFromCodeCoverage]
         public string FullMetadata()
         {
             StringWriter sw = new StringWriter(new StringBuilder());

--- a/Core/Repositories/AvailableModule.cs
+++ b/Core/Repositories/AvailableModule.cs
@@ -196,7 +196,10 @@ namespace CKAN
                 IndentChar  = ' '
             })
             {
-                new JsonSerializer().Serialize(writer, this);
+                new JsonSerializer()
+                {
+                    DateTimeZoneHandling = DateTimeZoneHandling.Utc,
+                }.Serialize(writer, this);
             }
             return sw.ToString();
         }

--- a/Core/Repositories/RepositoryData.cs
+++ b/Core/Repositories/RepositoryData.cs
@@ -123,7 +123,10 @@ namespace CKAN
                 Indentation = 0,
             })
             {
-                JsonSerializer serializer = new JsonSerializer();
+                JsonSerializer serializer = new JsonSerializer()
+                {
+                    DateTimeZoneHandling = DateTimeZoneHandling.Utc,
+                };
                 serializer.Serialize(writer, this);
             }
             var txFileMgr = new TxFileManager();

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -475,7 +475,10 @@ namespace CKAN
                 writer.Formatting  = Formatting.Indented;
                 writer.Indentation = 4;
                 writer.IndentChar  = ' ';
-                new JsonSerializer().Serialize(writer, this);
+                new JsonSerializer()
+                {
+                    DateTimeZoneHandling = DateTimeZoneHandling.Utc,
+                }.Serialize(writer, this);
             }
             return sw + Environment.NewLine;
         }

--- a/GUI/Controls/ChooseProvidedMods.cs
+++ b/GUI/Controls/ChooseProvidedMods.cs
@@ -32,7 +32,7 @@ namespace CKAN.GUI
             {
                 ChooseProvidedModsLabel.Text = message;
                 ChooseProvidedModsLabel.Height =
-                    Util.LabelStringHeight(CreateGraphics(), ChooseProvidedModsLabel);
+                    CreateGraphics().LabelStringHeight(ChooseProvidedModsLabel);
 
                 ChooseProvidedModsListView.Items.Clear();
                 ChooseProvidedModsListView.Items.AddRange(modules
@@ -55,7 +55,7 @@ namespace CKAN.GUI
         protected override void OnResize(EventArgs e)
         {
             base.OnResize(e);
-            ChooseProvidedModsLabel.Height = Util.LabelStringHeight(CreateGraphics(), ChooseProvidedModsLabel);
+            ChooseProvidedModsLabel.Height = CreateGraphics().LabelStringHeight(ChooseProvidedModsLabel);
         }
 
         [ForbidGUICalls]

--- a/GUI/Controls/DeleteDirectories.cs
+++ b/GUI/Controls/DeleteDirectories.cs
@@ -95,7 +95,7 @@ namespace CKAN.GUI
         protected override void OnResize(EventArgs e)
         {
             base.OnResize(e);
-            ExplanationLabel.Height = Util.LabelStringHeight(CreateGraphics(), ExplanationLabel);
+            ExplanationLabel.Height = CreateGraphics().LabelStringHeight(ExplanationLabel);
         }
 
         /// <summary>

--- a/GUI/Controls/DropdownMenuButton.cs
+++ b/GUI/Controls/DropdownMenuButton.cs
@@ -38,16 +38,18 @@ namespace CKAN.GUI
 
             if (Menu != null)
             {
-                int arrowX = ClientRectangle.Width - 14,
+                var factor = Util.TextScaleFactor;
+                int arrowX = ClientRectangle.Width - (int)(14 * factor),
                     arrowY = (ClientRectangle.Height / 2) - 1;
 
                 pevent.Graphics.FillPolygon(
                     Enabled ? SystemBrushes.ControlText : SystemBrushes.ButtonShadow,
                     new Point[]
                     {
-                        new Point(arrowX,     arrowY),
-                        new Point(arrowX + 7, arrowY),
-                        new Point(arrowX + 3, arrowY + 4)
+                        new Point(arrowX, arrowY),
+                        new Point(arrowX + (int)(7 * factor), arrowY),
+                        new Point(arrowX + (int)(3 * factor),
+                                  arrowY + (int)(4 * factor))
                     }
                 );
             }

--- a/GUI/Controls/EditModSearch.cs
+++ b/GUI/Controls/EditModSearch.cs
@@ -93,6 +93,9 @@ namespace CKAN.GUI
             }
         }
 
+        public Point ButtonLocation => Location + (Size)ExpandButton.Location;
+        public Size  ButtonSize     => ExpandButton.Size;
+
         public void CloseSearch(Point screenCoords)
         {
             // Treat the entire main window as an uncheck button, and let

--- a/GUI/Controls/EditModSearches.cs
+++ b/GUI/Controls/EditModSearches.cs
@@ -125,7 +125,7 @@ namespace CKAN.GUI
                 // Dock handles the layout for us
                 Dock      = DockStyle.Top,
                 ShowLabel = editors.Count < 1,
-                TabIndex  = editors.Count * 2
+                TabIndex  = AddSearchButton.TabIndex,
             };
             ctl.ApplySearch    += EditModSearch_ApplySearch;
             ctl.SurrenderFocus += EditModSearch_SurrenderFocus;
@@ -137,10 +137,23 @@ namespace CKAN.GUI
             ctl.BringToFront();
             // Still need to be able to see the add button, without this it's covered up
             AddSearchButton.BringToFront();
+            // Put it at the end of the tab order
+            ++AddSearchButton.TabIndex;
 
             Height = editors.Sum(ems => ems.Height);
 
             return ctl;
+        }
+
+        protected override void OnResize(EventArgs e)
+        {
+            base.OnResize(e);
+            if (editors.LastOrDefault() is EditModSearch ctl)
+            {
+                // Try to fit its size to the search box next to it
+                AddSearchButton.Size     = ctl.ButtonSize;
+                AddSearchButton.Location = ctl.ButtonLocation + new Size(AddSearchButton.Width, 0);
+            }
         }
 
         private void RemoveSearch(EditModSearch which)
@@ -158,6 +171,7 @@ namespace CKAN.GUI
 
                 editors.Remove(which);
                 Controls.Remove(which);
+                --AddSearchButton.TabIndex;
                 // Make sure the top label is always visible
                 if (//editors is [var editor, ..]
                     editors.Count > 0

--- a/GUI/Controls/ManageMods.Designer.cs
+++ b/GUI/Controls/ManageMods.Designer.cs
@@ -117,7 +117,7 @@ namespace CKAN.GUI
             this.Toolbar.Name = "Toolbar";
             this.Toolbar.ShowItemToolTips = true;
             this.Toolbar.Size = new System.Drawing.Size(5876, 48);
-            this.Toolbar.TabStop = true;
+            this.Toolbar.TabStop = false;
             this.Toolbar.TabIndex = 4;
             this.Toolbar.Text = "Toolbar";
             //

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -51,6 +51,7 @@ namespace CKAN.GUI
             FilterNotInstalledButton.ToolTipText    = Properties.Resources.FilterLinkToolTip;
             FilterIncompatibleButton.ToolTipText    = Properties.Resources.FilterLinkToolTip;
 
+            Toolbar.GotFocus += new EventHandler((sender, args) => ModGrid.Select());
             FilterToolButton.MouseHover += (sender, args) => FilterToolButton.ShowDropDown();
             ApplyToolButton.MouseHover += (sender, args) => ApplyToolButton.ShowDropDown();
             ApplyToolButton.Enabled = false;

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -61,6 +61,27 @@ namespace CKAN.GUI
                                                                      (sender, e) => Util.Invoke(this, () => ModGrid_SelectionChanged(sender, e)),
                                                                      100));
 
+            ModGrid.Resize += new EventHandler(Util.Debounce<EventArgs>(
+                                  (sender, e) => Util.Invoke(this, () =>
+                                  {
+                                      // Expand/contract large columns to use the available space efficiently
+                                      ModName.AutoSizeMode       = DataGridViewAutoSizeColumnMode.Fill;
+                                      Author.AutoSizeMode        = DataGridViewAutoSizeColumnMode.Fill;
+                                      LatestVersion.AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill;
+                                      Description.AutoSizeMode   = DataGridViewAutoSizeColumnMode.Fill;
+                                  }),
+                                  (sender, e) => false,
+                                  (sender, e) => false,
+                                  (sender, e) => Util.Invoke(this, () =>
+                                  {
+                                      // Now make them resizable again
+                                      ModName.AutoSizeMode       = DataGridViewAutoSizeColumnMode.NotSet;
+                                      Author.AutoSizeMode        = DataGridViewAutoSizeColumnMode.NotSet;
+                                      LatestVersion.AutoSizeMode = DataGridViewAutoSizeColumnMode.NotSet;
+                                      Description.AutoSizeMode   = DataGridViewAutoSizeColumnMode.NotSet;
+                                  }),
+                                  250));
+
             repoData = ServiceLocator.Container.Resolve<RepositoryDataManager>();
 
             navHistory = new NavigationHistory<GUIMod>();
@@ -1477,18 +1498,6 @@ namespace CKAN.GUI
         private void ModGrid_Resize(object? sender, EventArgs? e)
         {
             InstallAllCheckbox.Top = ModGrid.Top - InstallAllCheckbox.Height;
-
-            // Expand/contract large columns to use the available space efficiently
-            ModName.AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill;
-            Author.AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill;
-            LatestVersion.AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill;
-            Description.AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill;
-
-            // Now make them resizable again
-            ModName.AutoSizeMode = DataGridViewAutoSizeColumnMode.NotSet;
-            Author.AutoSizeMode = DataGridViewAutoSizeColumnMode.NotSet;
-            LatestVersion.AutoSizeMode = DataGridViewAutoSizeColumnMode.NotSet;
-            Description.AutoSizeMode = DataGridViewAutoSizeColumnMode.NotSet;
         }
 
         private void reinstallToolStripMenuItem_Click(object? sender, EventArgs? e)

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -94,11 +94,11 @@ namespace CKAN.GUI
             var g = CreateGraphics();
             ModGrid.ColumnHeadersHeight = ModGrid.Columns.OfType<DataGridViewColumn>().Max(col =>
                 ModGrid.ColumnHeadersDefaultCellStyle.Padding.Vertical
-                + Util.StringHeight(g, col.HeaderText,
-                                    col.HeaderCell?.Style?.Font
-                                                  ?? ModGrid.ColumnHeadersDefaultCellStyle.Font
-                                                  ?? SystemFonts.DefaultFont,
-                                    col.Width - (2 * ModGrid.ColumnHeadersDefaultCellStyle.Padding.Horizontal)));
+                + g.StringHeight(col.HeaderText,
+                                 col.HeaderCell?.Style?.Font
+                                               ?? ModGrid.ColumnHeadersDefaultCellStyle.Font
+                                               ?? SystemFonts.DefaultFont,
+                                 col.Width - (2 * ModGrid.ColumnHeadersDefaultCellStyle.Padding.Horizontal)));
         }
 
         private static readonly ILog log = LogManager.GetLogger(typeof(ManageMods));

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1751,20 +1751,20 @@ namespace CKAN.GUI
 
             UpdateFilters();
 
-            // Fit small columns to their contents at load
-            ModGrid.AutoResizeColumn(InstalledVersion.Index,  DataGridViewAutoSizeColumnMode.AllCellsExceptHeader);
-            ModGrid.AutoResizeColumn(GameCompatibility.Index, DataGridViewAutoSizeColumnMode.AllCellsExceptHeader);
-            ModGrid.AutoResizeColumn(DownloadSize.Index,      DataGridViewAutoSizeColumnMode.AllCellsExceptHeader);
-            ModGrid.AutoResizeColumn(InstallSize.Index,       DataGridViewAutoSizeColumnMode.AllCellsExceptHeader);
-            ModGrid.AutoResizeColumn(ReleaseDate.Index,       DataGridViewAutoSizeColumnMode.AllCellsExceptHeader);
-            ModGrid.AutoResizeColumn(InstallDate.Index,       DataGridViewAutoSizeColumnMode.AllCellsExceptHeader);
-            ModGrid.AutoResizeColumn(DownloadCount.Index,     DataGridViewAutoSizeColumnMode.AllCellsExceptHeader);
-
-            // Hide update and replacement columns if not needed.
-            // Write it to the configuration, else they are hidden again after a filter change.
-            // After the update / replacement, they are hidden again.
             Util.Invoke(ModGrid, () =>
             {
+                // Fit small columns to their contents at load
+                ModGrid.AutoResizeColumn(InstalledVersion.Index,  DataGridViewAutoSizeColumnMode.AllCellsExceptHeader);
+                ModGrid.AutoResizeColumn(GameCompatibility.Index, DataGridViewAutoSizeColumnMode.AllCellsExceptHeader);
+                ModGrid.AutoResizeColumn(DownloadSize.Index,      DataGridViewAutoSizeColumnMode.AllCellsExceptHeader);
+                ModGrid.AutoResizeColumn(InstallSize.Index,       DataGridViewAutoSizeColumnMode.AllCellsExceptHeader);
+                ModGrid.AutoResizeColumn(ReleaseDate.Index,       DataGridViewAutoSizeColumnMode.AllCellsExceptHeader);
+                ModGrid.AutoResizeColumn(InstallDate.Index,       DataGridViewAutoSizeColumnMode.AllCellsExceptHeader);
+                ModGrid.AutoResizeColumn(DownloadCount.Index,     DataGridViewAutoSizeColumnMode.AllCellsExceptHeader);
+
+                // Hide update and replacement columns if not needed.
+                // Write it to the configuration, else they are hidden again after a filter change.
+                // After the update / replacement, they are hidden again.
                 UpdateCol.Visible  = has_unheld_updates;
                 ReplaceCol.Visible = MainModList.Modules.Any(mod => mod.IsInstalled && mod.HasReplacement);
             });

--- a/GUI/Controls/ModInfo/Metadata.Designer.cs
+++ b/GUI/Controls/ModInfo/Metadata.Designer.cs
@@ -59,10 +59,11 @@ namespace CKAN.GUI
             //
             // MetadataTable
             //
+            this.MetadataTable.AutoSize = true;
             this.MetadataTable.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.MetadataTable.ColumnCount = 2;
-            this.MetadataTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.AutoSize));
-            this.MetadataTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.AutoSize));
+            this.MetadataTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 100));
+            this.MetadataTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100));
             this.MetadataTable.Controls.Add(this.VersionLabel, 0, 0);
             this.MetadataTable.Controls.Add(this.VersionTextBox, 1, 0);
             this.MetadataTable.Controls.Add(this.LicenseLabel, 0, 1);
@@ -93,27 +94,23 @@ namespace CKAN.GUI
             this.MetadataTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.AutoSize));
             this.MetadataTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.AutoSize));
             this.MetadataTable.Size = new System.Drawing.Size(346, 255);
-            this.MetadataTable.AutoSize = true;
             this.MetadataTable.TabIndex = 0;
+            this.MetadataTable.Resize += new System.EventHandler(this.MetadataTable_Resize);
             //
             // VersionLabel
             //
             this.VersionLabel.AutoSize = true;
-            this.VersionLabel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.VersionLabel.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.VersionLabel.Location = new System.Drawing.Point(3, 0);
             this.VersionLabel.Name = "VersionLabel";
-            this.VersionLabel.Size = new System.Drawing.Size(84, 30);
+            this.VersionLabel.Size = new System.Drawing.Size(84, 20);
             this.VersionLabel.TabIndex = 1;
             resources.ApplyResources(this.VersionLabel, "VersionLabel");
             //
             // VersionTextBox
             //
             this.VersionTextBox.AutoSize = true;
-            this.VersionTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.VersionTextBox.Location = new System.Drawing.Point(93, 0);
             this.VersionTextBox.Name = "VersionTextBox";
-            this.VersionTextBox.Size = new System.Drawing.Size(250, 30);
+            this.VersionTextBox.Size = new System.Drawing.Size(250, 20);
             this.VersionTextBox.TabIndex = 2;
             this.VersionTextBox.ReadOnly = true;
             this.VersionTextBox.BackColor = System.Drawing.SystemColors.Control;
@@ -124,21 +121,17 @@ namespace CKAN.GUI
             // LicenseLabel
             //
             this.LicenseLabel.AutoSize = true;
-            this.LicenseLabel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.LicenseLabel.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.LicenseLabel.Location = new System.Drawing.Point(3, 30);
             this.LicenseLabel.Name = "LicenseLabel";
-            this.LicenseLabel.Size = new System.Drawing.Size(84, 30);
+            this.LicenseLabel.Size = new System.Drawing.Size(84, 20);
             this.LicenseLabel.TabIndex = 3;
             resources.ApplyResources(this.LicenseLabel, "LicenseLabel");
             //
             // LicenseTextBox
             //
             this.LicenseTextBox.AutoSize = true;
-            this.LicenseTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.LicenseTextBox.Location = new System.Drawing.Point(93, 30);
             this.LicenseTextBox.Name = "LicenseTextBox";
-            this.LicenseTextBox.Size = new System.Drawing.Size(250, 30);
+            this.LicenseTextBox.Size = new System.Drawing.Size(250, 20);
             this.LicenseTextBox.TabIndex = 4;
             this.LicenseTextBox.ReadOnly = true;
             this.LicenseTextBox.BackColor = System.Drawing.SystemColors.Control;
@@ -149,21 +142,15 @@ namespace CKAN.GUI
             // AuthorLabel
             //
             this.AuthorLabel.AutoSize = true;
-            this.AuthorLabel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.AuthorLabel.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.AuthorLabel.Location = new System.Drawing.Point(3, 60);
             this.AuthorLabel.Name = "AuthorLabel";
-            this.AuthorLabel.Size = new System.Drawing.Size(84, 30);
+            this.AuthorLabel.Size = new System.Drawing.Size(84, 0);
             this.AuthorLabel.TabIndex = 5;
             resources.ApplyResources(this.AuthorLabel, "AuthorLabel");
             //
             // AuthorsPanel
             //
             this.AuthorsPanel.AutoSize = true;
-            this.AuthorsPanel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.AuthorsPanel.Margin = new System.Windows.Forms.Padding(4, 0, 0, 10);
-            this.AuthorsPanel.Padding = new System.Windows.Forms.Padding(0);
-            this.AuthorsPanel.Location = new System.Drawing.Point(0, 0);
             this.AuthorsPanel.Name = "AuthorsPanel";
             this.AuthorsPanel.TabIndex = 6;
             this.AuthorsPanel.Size = new System.Drawing.Size(500, 20);
@@ -171,21 +158,17 @@ namespace CKAN.GUI
             // DownloadCountLabel
             //
             this.DownloadCountLabel.AutoSize = true;
-            this.DownloadCountLabel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.DownloadCountLabel.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.DownloadCountLabel.Location = new System.Drawing.Point(0, 3);
             this.DownloadCountLabel.Name = "DownloadCountLabel";
-            this.DownloadCountLabel.Size = new System.Drawing.Size(84, 30);
+            this.DownloadCountLabel.Size = new System.Drawing.Size(84, 20);
             this.DownloadCountLabel.TabIndex = 7;
             resources.ApplyResources(this.DownloadCountLabel, "DownloadCountLabel");
             //
             // DownloadCountTextBox
             //
             this.DownloadCountTextBox.AutoSize = true;
-            this.DownloadCountTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.DownloadCountTextBox.Location = new System.Drawing.Point(0, 3);
             this.DownloadCountTextBox.Name = "DownloadCountTextBox";
-            this.DownloadCountTextBox.Size = new System.Drawing.Size(250, 30);
+            this.DownloadCountTextBox.Size = new System.Drawing.Size(250, 20);
             this.DownloadCountTextBox.TabIndex = 8;
             this.DownloadCountTextBox.ReadOnly = true;
             this.DownloadCountTextBox.BackColor = System.Drawing.SystemColors.Control;
@@ -196,21 +179,17 @@ namespace CKAN.GUI
             // ReleaseLabel
             //
             this.ReleaseLabel.AutoSize = true;
-            this.ReleaseLabel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.ReleaseLabel.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.ReleaseLabel.Location = new System.Drawing.Point(3, 150);
             this.ReleaseLabel.Name = "ReleaseLabel";
-            this.ReleaseLabel.Size = new System.Drawing.Size(84, 30);
+            this.ReleaseLabel.Size = new System.Drawing.Size(84, 20);
             this.ReleaseLabel.TabIndex = 9;
             resources.ApplyResources(this.ReleaseLabel, "ReleaseLabel");
             //
             // ReleaseStatusTextBox
             //
             this.ReleaseStatusTextBox.AutoSize = true;
-            this.ReleaseStatusTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.ReleaseStatusTextBox.Location = new System.Drawing.Point(93, 150);
             this.ReleaseStatusTextBox.Name = "ReleaseStatusTextBox";
-            this.ReleaseStatusTextBox.Size = new System.Drawing.Size(250, 30);
+            this.ReleaseStatusTextBox.Size = new System.Drawing.Size(250, 20);
             this.ReleaseStatusTextBox.TabIndex = 10;
             this.ReleaseStatusTextBox.ReadOnly = true;
             this.ReleaseStatusTextBox.BackColor = System.Drawing.SystemColors.Control;
@@ -221,21 +200,17 @@ namespace CKAN.GUI
             // GameCompatibilityLabel
             //
             this.GameCompatibilityLabel.AutoSize = true;
-            this.GameCompatibilityLabel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.GameCompatibilityLabel.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.GameCompatibilityLabel.Location = new System.Drawing.Point(3, 180);
             this.GameCompatibilityLabel.Name = "GameCompatibilityLabel";
-            this.GameCompatibilityLabel.Size = new System.Drawing.Size(84, 30);
+            this.GameCompatibilityLabel.Size = new System.Drawing.Size(84, 20);
             this.GameCompatibilityLabel.TabIndex = 11;
             resources.ApplyResources(this.GameCompatibilityLabel, "GameCompatibilityLabel");
             //
             // GameCompatibilityTextBox
             //
             this.GameCompatibilityTextBox.AutoSize = true;
-            this.GameCompatibilityTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.GameCompatibilityTextBox.Location = new System.Drawing.Point(93, 180);
             this.GameCompatibilityTextBox.Name = "GameCompatibilityTextBox";
-            this.GameCompatibilityTextBox.Size = new System.Drawing.Size(250, 30);
+            this.GameCompatibilityTextBox.Size = new System.Drawing.Size(250, 20);
             this.GameCompatibilityTextBox.TabIndex = 12;
             this.GameCompatibilityTextBox.ReadOnly = true;
             this.GameCompatibilityTextBox.BackColor = System.Drawing.SystemColors.Control;
@@ -246,9 +221,7 @@ namespace CKAN.GUI
             // IdentifierLabel
             //
             this.IdentifierLabel.AutoSize = true;
-            this.IdentifierLabel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.IdentifierLabel.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.IdentifierLabel.Location = new System.Drawing.Point(3, 210);
             this.IdentifierLabel.Name = "IdentifierLabel";
             this.IdentifierLabel.Size = new System.Drawing.Size(84, 20);
             this.IdentifierLabel.TabIndex = 13;
@@ -257,8 +230,6 @@ namespace CKAN.GUI
             // IdentifierTextBox
             //
             this.IdentifierTextBox.AutoSize = true;
-            this.IdentifierTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.IdentifierTextBox.Location = new System.Drawing.Point(93, 210);
             this.IdentifierTextBox.Name = "IdentifierTextBox";
             this.IdentifierTextBox.Size = new System.Drawing.Size(250, 20);
             this.IdentifierTextBox.TabIndex = 14;
@@ -271,9 +242,7 @@ namespace CKAN.GUI
             // ReplacementLabel
             //
             this.ReplacementLabel.AutoSize = true;
-            this.ReplacementLabel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.ReplacementLabel.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.ReplacementLabel.Location = new System.Drawing.Point(3, 240);
             this.ReplacementLabel.Name = "ReplacementLabel";
             this.ReplacementLabel.Size = new System.Drawing.Size(84, 20);
             this.ReplacementLabel.TabIndex = 15;
@@ -282,8 +251,6 @@ namespace CKAN.GUI
             // ReplacementTextBox
             //
             this.ReplacementTextBox.AutoSize = true;
-            this.ReplacementTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.ReplacementTextBox.Location = new System.Drawing.Point(93, 240);
             this.ReplacementTextBox.Name = "ReplacementTextBox";
             this.ReplacementTextBox.Size = new System.Drawing.Size(250, 20);
             this.ReplacementTextBox.TabIndex = 16;

--- a/GUI/Controls/ModInfo/Metadata.cs
+++ b/GUI/Controls/ModInfo/Metadata.cs
@@ -101,8 +101,8 @@ namespace CKAN.GUI
                     AddResourceLink(Properties.Resources.ModInfoGogStoreLabel,              res.gogstore);
                     AddResourceLink(Properties.Resources.ModInfoEpicStoreLabel,             res.epicstore);
                 }
+                WrapRows();
                 MetadataTable.ResumeLayout(true);
-                ResizeResourceRows();
             });
         }
 
@@ -178,14 +178,11 @@ namespace CKAN.GUI
             }
         }
 
-        private int LinkLabelStringHeight(LinkLabel lb, int fitWidth)
-            => lb.Padding.Vertical + lb.Margin.Vertical + 10
-                + Util.StringHeight(CreateGraphics(), lb.Text, lb.Font, fitWidth);
-
-        protected override void OnResize(EventArgs e)
+        private void MetadataTable_Resize(object sender, EventArgs args)
         {
-            base.OnResize(e);
-            ResizeResourceRows();
+            MetadataTable.SuspendLayout();
+            WrapRows();
+            MetadataTable.ResumeLayout(true);
         }
 
         private void ClearResourceLinks()
@@ -208,32 +205,23 @@ namespace CKAN.GUI
             }
         }
 
-        private int RightColumnWidth
-            => MetadataTable.Width
-                - MetadataTable.Padding.Horizontal
-                - MetadataTable.Margin.Horizontal
-                - (int)MetadataTable.ColumnStyles[0].Width;
-
         private void AddResourceLink(string label, Uri? link)
         {
-            const int vPadding = 3;
             if (link != null)
             {
                 Label lbl = new Label()
                 {
                     AutoSize  = true,
-                    Dock      = DockStyle.Fill,
                     ForeColor = SystemColors.GrayText,
-                    Padding   = new Padding(0, vPadding, 0, vPadding),
                     Text      = label,
                 };
                 LinkLabel llbl = new LinkLabel()
                 {
-                    AutoSize = false,
-                    Dock     = DockStyle.Fill,
-                    Padding  = new Padding(0, vPadding, 0, vPadding),
+                    AutoSize = true,
+                    Margin   = new Padding(4),
                     TabStop  = true,
-                    Text     = link.ToString(),
+                    Text     = link.OriginalString,
+                    Tag      = link,
                     // Lighter colors for dark mode
                     LinkColor = BackColor.LinkColorForBackColor(),
                 };
@@ -243,33 +231,40 @@ namespace CKAN.GUI
                 MetadataTable.Controls.Add(lbl,  0, row);
                 MetadataTable.Controls.Add(llbl, 1, row);
                 MetadataTable.RowCount = row + 1;
-                MetadataTable.RowStyles.Add(
-                    new RowStyle(SizeType.Absolute, Math.Max(
-                        // "Remote version file" wraps
-                        Util.LabelStringHeight(CreateGraphics(), lbl),
-                        LinkLabelStringHeight(llbl, RightColumnWidth))));
+                MetadataTable.RowStyles.Add(new RowStyle(SizeType.AutoSize));
             }
         }
 
-        private void ResizeResourceRows()
+        private void WrapRows()
         {
-            if (staticRowCount > 0)
+            const int bottomMargin = 10;
+            if (MetadataTable.GetColumnWidths() is { Length: >= 2 } colWidths)
             {
-                MetadataTable.SuspendLayout();
-                var rWidth = RightColumnWidth;
-                var g = CreateGraphics();
-                for (int row = staticRowCount; row < MetadataTable.RowStyles.Count; ++row)
+                for (int col = 0; col < MetadataTable.ColumnCount; ++col)
                 {
-                    if (MetadataTable.GetControlFromPosition(0, row) is Label lab
-                        && MetadataTable.GetControlFromPosition(1, row) is LinkLabel link)
+                    for (int row = 0; row < MetadataTable.RowCount; ++row)
                     {
-                        MetadataTable.RowStyles[row].Height = Math.Max(
-                            // "Remote version file" wraps
-                            Util.LabelStringHeight(g, lab),
-                            LinkLabelStringHeight(link, rWidth));
+                        switch (MetadataTable.GetControlFromPosition(col, row))
+                        {
+                            case TextBox tb:
+                                // Text boxes have internal padding that is about the size of the default label margin
+                                tb.Margin = new Padding(tb.Margin.Left, 0, tb.Margin.Right, bottomMargin);
+                                // Text boxes don't like using MaximumSize
+                                tb.Size   = new Size(colWidths[col] - tb.Margin.Horizontal,
+                                                     tb.StringHeight(colWidths[col] - tb.Margin.Horizontal));
+                                break;
+                            case FlowLayoutPanel flp:
+                                flp.Margin      = new Padding(flp.Margin.Left, 0, 0, bottomMargin);
+                                flp.MaximumSize = new Size(colWidths[col] - flp.Margin.Horizontal, 1000);
+                                break;
+                            case Control c:
+                                c.Margin      = new Padding(c.Margin.Left, c.Margin.Top, c.Margin.Right, bottomMargin);
+                                c.MaximumSize = new Size(colWidths[col] - c.Margin.Horizontal,
+                                                         c.StringHeight(colWidths[col] - c.Margin.Horizontal) + c.Margin.Vertical);
+                                break;
+                        }
                     }
                 }
-                MetadataTable.ResumeLayout(true);
             }
         }
 

--- a/GUI/Controls/ModInfo/Metadata.cs
+++ b/GUI/Controls/ModInfo/Metadata.cs
@@ -113,19 +113,21 @@ namespace CKAN.GUI
             AuthorsPanel.SuspendLayout();
             AuthorsPanel.Controls.Clear();
             AuthorsPanel.Controls.AddRange(
-                authors.Select(AuthorLink).ToArray());
+                authors.Select((a, i) => AuthorLink(a, i < authors.Count - 1)).ToArray());
             AuthorsPanel.ResumeLayout(true);
         }
 
-        private LinkLabel AuthorLink(string name)
+        private LinkLabel AuthorLink(string name, bool withComma)
         {
             var link = new LinkLabel()
             {
                 AutoSize     = true,
+                ForeColor    = SystemColors.GrayText,
                 LinkColor    = SystemColors.GrayText,
                 LinkBehavior = LinkBehavior.HoverUnderline,
-                Margin       = new Padding(0, 0, 4, 4),
-                Text         = name,
+                Margin       = new Padding(0, 0, 2, 2),
+                Text         = withComma ? $"{name}," : name,
+                LinkArea     = new LinkArea(0, name.Length),
                 Tag          = name,
             };
             link.LinkClicked += OnAuthorClick;

--- a/GUI/Controls/ModInfo/ModInfo.Designer.cs
+++ b/GUI/Controls/ModInfo/ModInfo.Designer.cs
@@ -78,7 +78,7 @@ namespace CKAN.GUI
             // MetadataModuleNameTextBox
             //
             this.MetadataModuleNameTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MetadataModuleNameTextBox.Font = new System.Drawing.Font(System.Drawing.SystemFonts.DefaultFont.FontFamily, 13, System.Drawing.FontStyle.Bold, System.Drawing.SystemFonts.CaptionFont.Unit);
+            this.MetadataModuleNameTextBox.Font = new System.Drawing.Font(System.Drawing.SystemFonts.DefaultFont.FontFamily, 13, System.Drawing.FontStyle.Bold, System.Drawing.SystemFonts.DefaultFont.Unit);
             this.MetadataModuleNameTextBox.Location = new System.Drawing.Point(3, 0);
             this.MetadataModuleNameTextBox.Name = "MetadataModuleNameTextBox";
             this.MetadataModuleNameTextBox.Size = new System.Drawing.Size(494, 46);

--- a/GUI/Controls/ModInfo/ModInfo.cs
+++ b/GUI/Controls/ModInfo/ModInfo.cs
@@ -124,8 +124,8 @@ namespace CKAN.GUI
 
         private int TextBoxStringHeight(TextBox tb)
             => tb.Padding.Vertical + tb.Margin.Vertical
-                + Util.StringHeight(CreateGraphics(), tb.Text, tb.Font,
-                                    tb.Width - tb.Padding.Horizontal - tb.Margin.Horizontal);
+                + tb.CreateGraphics().StringHeight(tb.Text, tb.Font,
+                                                   tb.Width - tb.Padding.Horizontal - tb.Margin.Horizontal);
 
         private int DescriptionHeight => TextBoxStringHeight(MetadataModuleDescriptionTextBox);
 

--- a/GUI/Controls/ModInfo/Relationships.cs
+++ b/GUI/Controls/ModInfo/Relationships.cs
@@ -27,6 +27,7 @@ namespace CKAN.GUI
         {
             InitializeComponent();
             LegendInstalledLabel.ScaleFonts();
+            LegendVirtualLabel.ScaleFonts();
             repoData = ServiceLocator.Container.Resolve<RepositoryDataManager>();
 
             ToolTip.SetToolTip(ReverseRelationshipsCheckbox, Properties.Resources.ModInfoToolTipReverseRelationships);
@@ -392,7 +393,7 @@ namespace CKAN.GUI
                                       ? LegendIncompatibleLabel.ForeColor
                                       : SystemColors.WindowText,
                 NodeFont    = installed ? LegendInstalledLabel.Font
-                                        : SystemFonts.DefaultFont,
+                                        : null,
             };
         }
 

--- a/GUI/Dialogs/CompatibleGameVersionsDialog.cs
+++ b/GUI/Dialogs/CompatibleGameVersionsDialog.cs
@@ -79,8 +79,7 @@ namespace CKAN.GUI
             {
                 MessageLabel.Text = msg;
                 MessageLabel.Visible = true;
-                MessageLabel.Height = Util.LabelStringHeight(CreateGraphics(),
-                                                             MessageLabel);
+                MessageLabel.Height = CreateGraphics().LabelStringHeight(MessageLabel);
                 Height += MessageLabel.Height;
             }
         }
@@ -90,8 +89,7 @@ namespace CKAN.GUI
             base.OnResize(e);
             if (MessageLabel.Visible)
             {
-                MessageLabel.Height = Util.LabelStringHeight(CreateGraphics(),
-                                                             MessageLabel);
+                MessageLabel.Height = CreateGraphics().LabelStringHeight(MessageLabel);
             }
         }
 

--- a/GUI/Dialogs/ErrorDialog.cs
+++ b/GUI/Dialogs/ErrorDialog.cs
@@ -43,10 +43,9 @@ namespace CKAN.GUI
                     ClientSize.Width,
                     Math.Min(
                         maxHeight,
-                        padding + Util.StringHeight(CreateGraphics(),
-                                                    ErrorMessage.Text,
-                                                    ErrorMessage.Font,
-                                                    ErrorMessage.Width - 4)));
+                        padding + CreateGraphics().StringHeight(ErrorMessage.Text,
+                                                                ErrorMessage.Font,
+                                                                ErrorMessage.Width - 4)));
                 if (!Visible)
                 {
                     StartPosition = mainForm.actuallyVisible

--- a/GUI/Dialogs/ManageGameInstancesDialog.Designer.cs
+++ b/GUI/Dialogs/ManageGameInstancesDialog.Designer.cs
@@ -121,20 +121,47 @@ namespace CKAN.GUI
             this.GameInstallPath.Width = 370;
             resources.ApplyResources(this.GameInstallPath, "GameInstallPath");
             //
-            // SelectButton
+            // SetAsDefaultCheckbox
             //
-            this.SelectButton.AutoSize = true;
-            this.SelectButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
-            this.SelectButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.SelectButton.Enabled = false;
-            this.SelectButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.SelectButton.Location = new System.Drawing.Point(459, 320);
-            this.SelectButton.Name = "SelectButton";
-            this.SelectButton.Size = new System.Drawing.Size(75, 23);
-            this.SelectButton.TabIndex = 1;
-            this.SelectButton.UseVisualStyleBackColor = true;
-            this.SelectButton.Click += new System.EventHandler(this.SelectButton_Click);
-            resources.ApplyResources(this.SelectButton, "SelectButton");
+            this.SetAsDefaultCheckbox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.SetAsDefaultCheckbox.AutoSize = true;
+            this.SetAsDefaultCheckbox.AutoCheck = false;
+            this.SetAsDefaultCheckbox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.SetAsDefaultCheckbox.Location = new System.Drawing.Point(12, 324);
+            this.SetAsDefaultCheckbox.Name = "SetAsDefaultCheckbox";
+            this.SetAsDefaultCheckbox.Size = new System.Drawing.Size(91, 17);
+            this.SetAsDefaultCheckbox.TabIndex = 4;
+            this.SetAsDefaultCheckbox.UseVisualStyleBackColor = true;
+            this.SetAsDefaultCheckbox.Click += new System.EventHandler(this.SetAsDefaultCheckbox_Click);
+            resources.ApplyResources(this.SetAsDefaultCheckbox, "SetAsDefaultCheckbox");
+            //
+            // ForgetButton
+            //
+            this.ForgetButton.AutoSize = true;
+            this.ForgetButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
+            this.ForgetButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.ForgetButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.ForgetButton.Location = new System.Drawing.Point(121, 320);
+            this.ForgetButton.Name = "ForgetButton";
+            this.ForgetButton.Size = new System.Drawing.Size(80, 23);
+            this.ForgetButton.TabIndex = 5;
+            this.ForgetButton.UseVisualStyleBackColor = true;
+            this.ForgetButton.Click += new System.EventHandler(this.Forget_Click);
+            resources.ApplyResources(this.ForgetButton, "ForgetButton");
+            //
+            // RenameButton
+            //
+            this.RenameButton.AutoSize = true;
+            this.RenameButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
+            this.RenameButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.RenameButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.RenameButton.Location = new System.Drawing.Point(207, 320);
+            this.RenameButton.Name = "RenameButton";
+            this.RenameButton.Size = new System.Drawing.Size(80, 23);
+            this.RenameButton.TabIndex = 3;
+            this.RenameButton.UseVisualStyleBackColor = true;
+            this.RenameButton.Click += new System.EventHandler(this.RenameButton_Click);
+            resources.ApplyResources(this.RenameButton, "RenameButton");
             //
             // AddNewButton
             //
@@ -142,10 +169,11 @@ namespace CKAN.GUI
             this.AddNewButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
             this.AddNewButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.AddNewButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.AddNewButton.Location = new System.Drawing.Point(327, 320);
+            this.AddNewButton.Location = new System.Drawing.Point(293, 320);
+            this.AddNewButton.Padding = new System.Windows.Forms.Padding(0);
             this.AddNewButton.Menu = this.AddNewMenu;
             this.AddNewButton.Name = "AddNewButton";
-            this.AddNewButton.Size = new System.Drawing.Size(126, 23);
+            this.AddNewButton.Size = new System.Drawing.Size(160, 23);
             this.AddNewButton.TabIndex = 2;
             this.AddNewButton.UseVisualStyleBackColor = true;
             resources.ApplyResources(this.AddNewButton, "AddNewButton");
@@ -180,47 +208,20 @@ namespace CKAN.GUI
             this.CloneGameInstanceMenuItem.Click += new System.EventHandler(this.CloneGameInstanceMenuItem_Click);
             resources.ApplyResources(this.CloneGameInstanceMenuItem, "CloneGameInstanceMenuItem");
             //
-            // RenameButton
+            // SelectButton
             //
-            this.RenameButton.AutoSize = true;
-            this.RenameButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
-            this.RenameButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.RenameButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.RenameButton.Location = new System.Drawing.Point(216, 320);
-            this.RenameButton.Name = "RenameButton";
-            this.RenameButton.Size = new System.Drawing.Size(105, 23);
-            this.RenameButton.TabIndex = 3;
-            this.RenameButton.UseVisualStyleBackColor = true;
-            this.RenameButton.Click += new System.EventHandler(this.RenameButton_Click);
-            resources.ApplyResources(this.RenameButton, "RenameButton");
-            //
-            // SetAsDefaultCheckbox
-            //
-            this.SetAsDefaultCheckbox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.SetAsDefaultCheckbox.AutoSize = true;
-            this.SetAsDefaultCheckbox.AutoCheck = false;
-            this.SetAsDefaultCheckbox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.SetAsDefaultCheckbox.Location = new System.Drawing.Point(12, 324);
-            this.SetAsDefaultCheckbox.Name = "SetAsDefaultCheckbox";
-            this.SetAsDefaultCheckbox.Size = new System.Drawing.Size(91, 17);
-            this.SetAsDefaultCheckbox.TabIndex = 4;
-            this.SetAsDefaultCheckbox.UseVisualStyleBackColor = true;
-            this.SetAsDefaultCheckbox.Click += new System.EventHandler(this.SetAsDefaultCheckbox_Click);
-            resources.ApplyResources(this.SetAsDefaultCheckbox, "SetAsDefaultCheckbox");
-            //
-            // ForgetButton
-            //
-            this.ForgetButton.AutoSize = true;
-            this.ForgetButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
-            this.ForgetButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.ForgetButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.ForgetButton.Location = new System.Drawing.Point(140, 320);
-            this.ForgetButton.Name = "ForgetButton";
-            this.ForgetButton.Size = new System.Drawing.Size(70, 23);
-            this.ForgetButton.TabIndex = 5;
-            this.ForgetButton.UseVisualStyleBackColor = true;
-            this.ForgetButton.Click += new System.EventHandler(this.Forget_Click);
-            resources.ApplyResources(this.ForgetButton, "ForgetButton");
+            this.SelectButton.AutoSize = true;
+            this.SelectButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
+            this.SelectButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.SelectButton.Enabled = false;
+            this.SelectButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.SelectButton.Location = new System.Drawing.Point(459, 320);
+            this.SelectButton.Name = "SelectButton";
+            this.SelectButton.Size = new System.Drawing.Size(75, 23);
+            this.SelectButton.TabIndex = 1;
+            this.SelectButton.UseVisualStyleBackColor = true;
+            this.SelectButton.Click += new System.EventHandler(this.SelectButton_Click);
+            resources.ApplyResources(this.SelectButton, "SelectButton");
             //
             // ManageGameInstancesDialog
             //

--- a/GUI/Dialogs/YesNoDialog.cs
+++ b/GUI/Dialogs/YesNoDialog.cs
@@ -79,7 +79,7 @@ namespace CKAN.GUI
             SuppressCheckbox.Visible = true;
         }
 
-        private const int maxHeight = 600;
+        private static int maxHeight => (int)(Util.TextScaleFactor * 600);
         private TaskCompletionSource<Tuple<DialogResult, bool>>? task;
         private readonly string defaultYes;
         private readonly string defaultNo;

--- a/GUI/Dialogs/YesNoDialog.cs
+++ b/GUI/Dialogs/YesNoDialog.cs
@@ -53,7 +53,7 @@ namespace CKAN.GUI
 
         private void Setup(string text, string? yesText, string? noText)
         {
-            var height = Util.StringHeight(CreateGraphics(), text, DescriptionLabel.Font, ClientSize.Width - 25) + (2 * 54);
+            var height = CreateGraphics().StringHeight(text, DescriptionLabel.Font, ClientSize.Width - 25) + (2 * 54);
             DescriptionLabel.Text = text;
             DescriptionLabel.TextAlign = text.Contains("\n")
                 ? HorizontalAlignment.Left

--- a/GUI/Extensions/WinFormsExtensions.cs
+++ b/GUI/Extensions/WinFormsExtensions.cs
@@ -71,6 +71,20 @@ namespace CKAN.GUI
                     strip.ScaleToolTipFonts();
                 }
             }
+            else if (Util.TextScaleFactor is not 1f and var factor)
+            {
+                if (control is Form)
+                {
+                    control.SuspendLayout();
+                    control.Scale(new SizeF(factor, factor));
+                    control.ResumeLayout(true);
+                }
+                if (control is ToolStrip or ProgressBar or Label or TreeView)
+                {
+                    control.Font = new Font(control.Font.FontFamily,
+                                            control.Font.Size * factor);
+                }
+            }
         }
 
         public static void ScaleFonts(this ToolStripItem item)
@@ -80,6 +94,11 @@ namespace CKAN.GUI
                 && dpi != 96)
             {
                 item.Font = item.Font.Scale(dpi);
+            }
+            else if (Util.TextScaleFactor is not 1f and var factor)
+            {
+                item.Font = new Font(item.Font.FontFamily,
+                                     item.Font.Size * factor);
             }
         }
 

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -119,7 +119,11 @@ namespace CKAN.GUI
             StatusInstanceLabel.ScaleFonts();
             StatusProgress.ScaleFonts();
             minimizedContextMenuStrip.ScaleFonts();
-            this.ScaleFonts();
+            if (Platform.IsMono)
+            {
+                // This breaks ModInfo scaling on Windows
+                this.ScaleFonts();
+            }
             // React when the user clicks a tag or filter link in mod info
             ModInfo.OnChangeFilter += ManageMods.Filter;
             ModInfo.ModuleDoubleClicked += ManageMods.ResetFilterAndSelectModOnList;

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -213,7 +213,7 @@ namespace CKAN.GUI
             var downloadSize   = new DataGridViewTextBoxCell { Value = mod.DownloadSize ?? ""                                };
             var installSize    = new DataGridViewTextBoxCell { Value = mod.InstallSize                                       };
             var releaseDate    = new DataGridViewTextBoxCell { Value = (object?)mod.Module.release_date?.ToLocalTime() ?? "" };
-            var installDate    = new DataGridViewTextBoxCell { Value = (object?)mod.InstallDate ?? ""                        };
+            var installDate    = new DataGridViewTextBoxCell { Value = (object?)mod.InstallDate?.ToLocalTime() ?? ""         };
             var downloadCount  = new DataGridViewTextBoxCell { Value = $"{mod.DownloadCount:N0}"                             };
             var desc           = new DataGridViewTextBoxCell
                                  {

--- a/GUI/Program.cs
+++ b/GUI/Program.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Linq;
+#if NET6_0_OR_GREATER
+using System.Drawing;
+#endif
 using System.Windows.Forms;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
@@ -36,6 +39,15 @@ namespace CKAN.GUI
             {
                 // By default, Windows will stretch the window and make it blurry; tell it not to.
                 SetProcessDPIAware();
+                #if NET6_0_OR_GREATER
+                Application.SetHighDpiMode(HighDpiMode.PerMonitorV2);
+                if (Util.TextScaleFactor is not 1f and var factor)
+                {
+                    Application.SetDefaultFont(
+                        new Font(SystemFonts.DefaultFont.FontFamily,
+                                 SystemFonts.DefaultFont.SizeInPoints * factor));
+                }
+                #endif
             }
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);

--- a/GUI/Util.cs
+++ b/GUI/Util.cs
@@ -448,8 +448,9 @@ namespace CKAN.GUI
         /// <returns>
         /// Number of pixels needed vertically to fit the string
         /// </returns>
-        public static int StringHeight(Graphics g, string text, Font font, int maxWidth)
-            => (int)g.MeasureString(text, font, (int)(maxWidth / XScale(g))).Height;
+        public static int StringHeight(this Graphics g, string text, Font font, int maxWidth)
+            => Platform.IsMono ? (int)g.MeasureString(text, font, (int)(maxWidth / XScale(g))).Height
+                               : (int)g.MeasureString(text, font, maxWidth).Height;
 
         /// <summary>
         /// Calculate how much vertical space is needed to display a label's text
@@ -459,11 +460,11 @@ namespace CKAN.GUI
         /// <returns>
         /// Number of pixels needed vertically to show the label's full text
         /// </returns>
-        public static int LabelStringHeight(Graphics g, Label lbl)
+        public static int LabelStringHeight(this Graphics g, Label lbl)
             => (int)(YScale(g) * (lbl.Margin.Vertical + lbl.Padding.Vertical
-                                  + StringHeight(g, lbl.Text, lbl.Font,
-                                                 (lbl.Width - lbl.Margin.Horizontal
-                                                            - lbl.Padding.Horizontal))));
+                                  + g.StringHeight(lbl.Text, lbl.Font,
+                                                   (lbl.Width - lbl.Margin.Horizontal
+                                                              - lbl.Padding.Horizontal))));
 
         #endregion
 

--- a/GUI/Util.cs
+++ b/GUI/Util.cs
@@ -448,10 +448,12 @@ namespace CKAN.GUI
         /// <returns>
         /// Number of pixels needed vertically to fit the string
         /// </returns>
+        [ExcludeFromCodeCoverage]
         public static int StringHeight(this Graphics g, string text, Font font, int maxWidth)
             => Platform.IsMono ? (int)g.MeasureString(text, font, (int)(maxWidth / XScale(g))).Height
                                : (int)g.MeasureString(text, font, maxWidth).Height;
 
+        [ExcludeFromCodeCoverage]
         public static int StringHeight<T>(this T c, int maxWidth)
             where T : Control
             => c.CreateGraphics().StringHeight(c.Text, c.Font, maxWidth);
@@ -464,6 +466,7 @@ namespace CKAN.GUI
         /// <returns>
         /// Number of pixels needed vertically to show the label's full text
         /// </returns>
+        [ExcludeFromCodeCoverage]
         public static int LabelStringHeight(this Graphics g, Label lbl)
             => (int)(YScale(g) * (lbl.Margin.Vertical + lbl.Padding.Vertical
                                   + g.StringHeight(lbl.Text, lbl.Font,
@@ -495,6 +498,7 @@ namespace CKAN.GUI
                                                ?? false);
         #pragma warning restore IDE0075
 
+        [ExcludeFromCodeCoverage]
         public static float TextScaleFactor
             #if NET6_0_OR_GREATER
             => Platform.IsWindows
@@ -538,7 +542,10 @@ namespace CKAN.GUI
             }
         }
 
+        [ExcludeFromCodeCoverage]
         private static float XScale(Graphics g) => g.DpiX / 96f;
+
+        [ExcludeFromCodeCoverage]
         private static float YScale(Graphics g) => g.DpiY / 96f;
 
         private static readonly ILog log = LogManager.GetLogger(typeof(Util));

--- a/GUI/Util.cs
+++ b/GUI/Util.cs
@@ -16,7 +16,7 @@ using log4net;
 
 namespace CKAN.GUI
 {
-    #if NET10_0_OR_GREATER
+    #if NET6_0_OR_GREATER
     using WinReg = Microsoft.Win32.Registry;
     #endif
 
@@ -472,6 +472,7 @@ namespace CKAN.GUI
 
         #endregion
 
+        #pragma warning disable IDE0075
         public static bool DarkMode => Platform.IsWindows
                                            #if NET10_0_OR_GREATER
                                            ? Platform.IsWindows11
@@ -492,6 +493,17 @@ namespace CKAN.GUI
                                                                      "read -g AppleInterfaceStyle",
                                                                      "Dark")
                                                ?? false);
+        #pragma warning restore IDE0075
+
+        public static float TextScaleFactor
+            #if NET6_0_OR_GREATER
+            => Platform.IsWindows
+               && WinReg.GetValue(TextScaleFactorKey, "TextScaleFactor", 100)
+                  is >= 100 and <= 300 and int f
+                      ? f / 100f : 1;
+            #else
+            => 1;
+            #endif
 
         private static bool? CommandOutputContains(string command, string args, string checkFor)
             => Utilities.DefaultIfThrows(() => Process.Start(new ProcessStartInfo()
@@ -506,6 +518,10 @@ namespace CKAN.GUI
 
         #if NET10_0_OR_GREATER
         private const string DarkModeKey = @"HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize";
+        #endif
+
+        #if NET6_0_OR_GREATER
+        private const string TextScaleFactorKey = @"HKEY_CURRENT_USER\Software\Microsoft\Accessibility";
         #endif
 
         // Hides the console window on Windows

--- a/GUI/Util.cs
+++ b/GUI/Util.cs
@@ -452,6 +452,10 @@ namespace CKAN.GUI
             => Platform.IsMono ? (int)g.MeasureString(text, font, (int)(maxWidth / XScale(g))).Height
                                : (int)g.MeasureString(text, font, maxWidth).Height;
 
+        public static int StringHeight<T>(this T c, int maxWidth)
+            where T : Control
+            => c.CreateGraphics().StringHeight(c.Text, c.Font, maxWidth);
+
         /// <summary>
         /// Calculate how much vertical space is needed to display a label's text
         /// </summary>

--- a/Netkan/Processors/QueueHandler.cs
+++ b/Netkan/Processors/QueueHandler.cs
@@ -331,7 +331,10 @@ namespace CKAN.NetKAN.Processors
                     IndentChar  = ' ',
                 })
             {
-                var serializer = new JsonSerializer();
+                var serializer = new JsonSerializer()
+                {
+                    DateTimeZoneHandling = DateTimeZoneHandling.Utc,
+                };
                 serializer.Serialize(writer, ckan.AllJson);
             }
             return sw + Environment.NewLine;

--- a/Netkan/Program.cs
+++ b/Netkan/Program.cs
@@ -202,7 +202,10 @@ namespace CKAN.NetKAN
                 jwriter.Indentation = 4;
                 jwriter.IndentChar = ' ';
 
-                var serializer = new JsonSerializer();
+                var serializer = new JsonSerializer()
+                {
+                    DateTimeZoneHandling = DateTimeZoneHandling.Utc,
+                };
                 serializer.Serialize(jwriter, json);
 
                 (swriter + Environment.NewLine).WriteThroughTo(finalPath);

--- a/Tests/Core/IO/ModuleInstallerTests.cs
+++ b/Tests/Core/IO/ModuleInstallerTests.cs
@@ -22,6 +22,7 @@ using CKAN.Games.KerbalSpaceProgram2;
 
 using Tests.Core.Configuration;
 using Tests.Data;
+using Tests.Core.Relationships;
 
 namespace Tests.Core.IO
 {
@@ -1505,10 +1506,10 @@ namespace Tests.Core.IO
         {
             // Arrange
             var user = new NullUser();
-            using (var cacheDir = new TemporaryDirectory())
             using (var inst     = new DisposableKSP())
             using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
             using (var regMgr   = RegistryManager.Instance(inst.KSP, new RepositoryDataManager()))
+            using (var cacheDir = new TemporaryDirectory())
             using (var cache    = new NetModuleCache(cacheDir))
             {
                 var installer = new ModuleInstaller(inst.KSP, cache, config, user);
@@ -1568,6 +1569,51 @@ namespace Tests.Core.IO
                 {
                     DirectoryAssert.Exists(absPath);
                 }
+            }
+        }
+
+        [TestCase(true), TestCase(false)]
+        public void UninstallList_ModInStockFolder_DoesNotOfferToDeleteStockFolder(bool stockDirEmpty)
+        {
+            // Arrange
+            var user = new NullUser();
+            using (var inst     = new DisposableKSP())
+            using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
+            using (var regMgr   = RegistryManager.Instance(inst.KSP, new RepositoryDataManager()))
+            using (var cacheDir = new TemporaryDirectory())
+            using (var cache    = new NetModuleCache(cacheDir))
+            {
+                var installer = new ModuleInstaller(inst.KSP, cache, config, user);
+                var mod = CkanModule.FromJson(RelationshipResolverTests.MergeWithDefaults(
+                    @"{
+                        ""identifier"": ""KSPArtemisSuit""
+                    }"));
+                var absPaths = new string[]
+                               {
+                                   "GameData/Squad/Artemis_Suit/README.txt",
+                                   "GameData/Squad/Artemis_Suit/Config/SUITCOMBOS.cfg",
+                                   "GameData/Squad/Artemis_Suit/Icons/icon1.png",
+                                   "GameData/Squad/Artemis_Suit/Icons/icon2.png",
+                                   "GameData/Squad/Artemis_Suit/Textures/SoupAerospace.png",
+                               }.Select(inst.KSP.ToAbsoluteGameDir)
+                                .ToArray();
+                foreach (var f in stockDirEmpty
+                                      ? absPaths
+                                      : absPaths.Prepend(inst.KSP.ToAbsoluteGameDir("GameData/Squad/stockstuff.txt")))
+                {
+                    Directory.CreateDirectory(Path.GetDirectoryName(f)!);
+                    File.WriteAllText(f, "");
+                }
+                regMgr.registry.RegisterModule(mod, absPaths, inst.KSP, false);
+
+                // Act
+                HashSet<string>? possibleConfigOnlyDirs = null;
+                installer.UninstallList(new string[] { "KSPArtemisSuit" },
+                                        ref possibleConfigOnlyDirs, regMgr, false);
+
+                // Assert
+                DirectoryAssert.Exists(inst.KSP.ToAbsoluteGameDir("GameData/Squad"));
+                Assert.That(possibleConfigOnlyDirs, Is.Null.Or.Empty);
             }
         }
 


### PR DESCRIPTION
## Problems

- If you install `KSPArtemisSuit` and then uninstall it, CKAN offers to delete `GameData/Squad`:
  <img width="1279" height="1033" alt="Image" src="https://github.com/user-attachments/assets/f5e15b4d-6da3-4c53-8f95-ae4ebf786c51" />
- If you install a mod, the value in the Install Time column is correct initially, but changes to UTC if you close and re-open CKAN.
  Reported by @KerballOne in #4638.
- When the system DPI is higher than 96, some places in the GUI appear too tall, such as the description in mod info.
- The Metadata tab in mod info still has some alignment and wrapping issues, especially with the resource links.
- I encountered a scenario where the GUI froze on loading in the current dev build.
- Resizing can be a bit jittery in the current dev build.
- If you install some mods, the Play button in the toolbar often steals focus and shows its dropdown afterwards.
- The button for adding a new search should be aligned and sized to match up nicely with the bottommost search's dropdown button, but it isn't quite.

## Causes

- Originally, CKAN would simply ignore folders that had files it did not install when uninstalling, and this protected `GameData/Squad`, since it would always have such files. (Notably, if you test with an empty `Squad` folder, even the old code deletes it!)
  Later, #2962 added the ability to ask the user what to do about such folders at uninstallation. For typical mod folders, this means asking about leftover settings or cached files. However, no special provisions were added to protect `GameData/Squad`, so it was possible for it to appear in the list of directories the user might choose to delete.
- The install timestamp was serialized with a timezone marker, then deserialized into UTC and rendered as-is, which shows the UTC version.
- `Util.StringHeight` included logic to account for DPI scaling, but this was redundant with the underlying `Graphics.MeasureString` function on Windows, which already handles DPI scaling.
- `ModInfo` uses a 2-column `TableLayoutPanel` to arrange its labels and values. The columns were both set to `AutoSize` mode, which meant their widths depended on their contents. But the values (especially the links) can wrap, which meant that the widths of the contents also depended on the widths of the columns! This circular dependency meant there was not really a stable configuration of the overall system. There were also some quirks of some values having different heights, and the logic to wrap the links relied on setting the table's row heights, which was kind of crazy.
- The new column auto sizing on load from #4671 was sometimes doing GUI operations outside the GUI thread, which is a no-no in WinForms.
- `ManageMods.OnResize` was setting the auto size mode twice for each column, which probably incurred extra layout processing.
- Clicking a button in the toolbar gives it focus, and when installation finishes, the Apply button is disabled, which transfers focus to the first button in the toolbar.
- The new-search button's size was static, whereas the dropdown's size is set to match the adjacent `TextBox`'s height, which is unpredictable. The new-search button's position relied on anchoring to the right and bottom, which moved it up and down appropriately, but didn't achieve pixel-perfect alignment.

## Motivations

- Author names in mod info are shown with just space between them. Since they can contain spaces internally, this is a bit visually ambiguous.
- #4543 added DPI-based UI scaling, so text would always appear the same physical size regardless of monitor specifications. Windows also has a separate text scaling setting, and it would be nice to support that as well.

## Changes

- Now `ModuleInstaller.Uninstall` excludes everything in `IGame.StockFolders` from its `possibleConfigOnlyDirs` output parameter, and will also not delete them if empty.
  Tests are included to exercise this that fail on the old code and pass on the new code.
  Fixes #4676.
- Now we serialize dates in UTC and use `.ToLocalTime()` to convert the install timestamp to local time.
- Now the DPI scaling in `Util.StringHeight` is Mono-only.
- Now the `ModInfo` table's left column has a static width, and the right column takes up the remaining space, which finally clearly defines who is in charge of setting the widths. The links are then much easier to wrap by simply setting `MaximumSize.Width`, which we do in a new handler for the table's `Resize` event. Many other quirks were ironed out as well.
- Now the column auto sizing on load is moved inside of a `Util.Invoke` call to put it on the GUI thread.
- Now the column auto sizing on resize is debounced, so we set the appropriate columns to `Fill` mode immediately, and then set them back to `NotSet` 250 milliseconds after the last resize event. This way the normal sizing logic can handle rapid events without worrying about modes being toggled.
- Now the toolbar is taken out of the tab order, and when it receives focus, we set focus back to the grid.
- Now `EditModSearch` exposes `ButtonLocation` and `ButtonSize` properties to tell its parent control where its button is, which `EditModSearches` uses in its `Resize` handler to move the new-search button to the immediate right edge of the dropdown button at a matching size.
- Now the author name links have commas after them.
- Now if the Windows text scaling setting (registry key `HKEY_CURRENT_USER\Software\Microsoft\Accessibility\TextScaleFactor`) is set to something greater than 100%, the .NET 10 build uses `Application.SetDefaultFont` to scale the default font, and `Form.Scale` is used to scale the various forms by the same amount. An exception is made for `Main` because mod info's layout breaks if we scale the main form. We can enable that in the future if we figure out the reason, but for now it's not really needed because the main form doesn't use static layout the way the settings dialog does.
  The net481 build is not changed because `Application.SetDefaultFont` is not available in that version.
  Fixes #4673.
