### PR TITLE
More upgradability optimizations

### DIFF
--- a/Cmdline/Action/Upgrade.cs
+++ b/Cmdline/Action/Upgrade.cs
@@ -136,9 +136,8 @@ namespace CKAN.CmdLine
             user.RaiseMessage(Properties.Resources.UpgradeQueryingCKAN);
             try
             {
-                var upd = new AutoUpdate();
-                var update = upd.GetUpdate(config.DevBuilds ?? false,
-                                           options.NetUserAgent);
+                var upd = new AutoUpdate(options.NetUserAgent);
+                var update = upd.GetUpdate(config.DevBuilds ?? false);
                 if (update.Version is CkanModuleVersion latestVersion
                     && !latestVersion.SameClientVersion(Meta.ReleaseVersion))
                 {

--- a/Core/AutoUpdate/AutoUpdate.cs
+++ b/Core/AutoUpdate/AutoUpdate.cs
@@ -1,10 +1,12 @@
 #if NET5_0_OR_GREATER
 using System;
 #endif
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Diagnostics;
+#if !NET5_0_OR_GREATER
 using System.Reflection;
+#endif
 using System.Diagnostics.CodeAnalysis;
 
 namespace CKAN
@@ -16,24 +18,21 @@ namespace CKAN
     [ExcludeFromCodeCoverage]
     public class AutoUpdate
     {
-        public AutoUpdate()
+        public AutoUpdate(string? userAgent)
         {
+            this.userAgent = userAgent;
         }
 
-        public CkanUpdate GetUpdate(bool devBuild, string? userAgent = null)
-        {
-            if (updates.TryGetValue(devBuild, out CkanUpdate? update))
-            {
-                return update;
-            }
-            var newUpdate = devBuild
-                ? new S3BuildCkanUpdate(null, userAgent) as CkanUpdate
-                : new GitHubReleaseCkanUpdate(null, userAgent);
-            updates.Add(devBuild, newUpdate);
-            return newUpdate;
-        }
+        public CkanUpdate GetUpdate(bool devBuild, bool bypassCache = false)
+            => bypassCache ? updates.AddOrUpdate(devBuild, GetUpdateUncached,
+                                                           (dev, upd) => GetUpdateUncached(dev))
+                           : updates.GetOrAdd(devBuild, GetUpdateUncached);
 
-        private readonly Dictionary<bool, CkanUpdate> updates = new Dictionary<bool, CkanUpdate>();
+        private CkanUpdate GetUpdateUncached(bool devBuild)
+            => devBuild ? new S3BuildCkanUpdate(null, userAgent)
+                        : new GitHubReleaseCkanUpdate(null, userAgent);
+
+        private readonly ConcurrentDictionary<bool, CkanUpdate> updates = new ConcurrentDictionary<bool, CkanUpdate>();
 
         private static string PathToRunningExe()
             #if NET5_0_OR_GREATER
@@ -63,7 +62,7 @@ namespace CKAN
         {
             var pid = Process.GetCurrentProcess().Id;
 
-            var update = GetUpdate(devBuild, userAgent);
+            var update = GetUpdate(devBuild);
 
             // download updater app and new ckan.exe
             NetAsyncDownloader.DownloadWithProgress(update.Targets, userAgent, user);
@@ -119,5 +118,7 @@ namespace CKAN
                 return false;
             }
         }
+
+        private readonly string? userAgent;
     }
 }

--- a/Core/GameInstance.cs
+++ b/Core/GameInstance.cs
@@ -71,7 +71,7 @@ namespace CKAN
         [MemberNotNull(nameof(playTime))]
         private void SetupCkanDirectories()
         {
-            log.InfoFormat("Initialising {0}", Platform.FormatPath(CkanDir));
+            log.DebugFormat("Initialising {0}", Platform.FormatPath(CkanDir));
 
             // TxFileManager knows if we are in a transaction
             var txFileMgr = new TxFileManager(CkanDir);
@@ -90,7 +90,7 @@ namespace CKAN
                 log.DebugFormat(Properties.Resources.GameInstanceCreatingDir, InstallHistoryDir);
                 txFileMgr.CreateDirectory(InstallHistoryDir);
             }
-            log.InfoFormat("Initialised {0}", Platform.FormatPath(CkanDir));
+            log.DebugFormat("Initialised {0}", Platform.FormatPath(CkanDir));
         }
 
         #endregion

--- a/Core/Games/KerbalSpaceProgram/GameVersionProviders/IKspBuildMap.cs
+++ b/Core/Games/KerbalSpaceProgram/GameVersionProviders/IKspBuildMap.cs
@@ -1,5 +1,4 @@
 using CKAN.Versioning;
-using System.Collections.Generic;
 
 namespace CKAN.Games.KerbalSpaceProgram.GameVersionProviders
 {
@@ -7,7 +6,7 @@ namespace CKAN.Games.KerbalSpaceProgram.GameVersionProviders
     {
         GameVersion? this[string buildId] { get; }
 
-        List<GameVersion> KnownVersions { get; }
+        GameVersion[] KnownVersions { get; }
 
         /// <summary>
         /// Download the build map from the server to the cache

--- a/Core/Games/KerbalSpaceProgram/GameVersionProviders/KspBuildMap.cs
+++ b/Core/Games/KerbalSpaceProgram/GameVersionProviders/KspBuildMap.cs
@@ -53,14 +53,14 @@ namespace CKAN.Games.KerbalSpaceProgram.GameVersionProviders
             }
         }
 
-        public List<GameVersion> KnownVersions
+        public GameVersion[] KnownVersions
         {
             get
             {
                 EnsureBuildMap();
                 return _jBuilds?.Builds?.Select(b => GameVersion.Parse(b.Value))
-                                        .ToList()
-                               ?? new List<GameVersion>();
+                                        .ToArray()
+                               ?? Array.Empty<GameVersion>();
             }
         }
 

--- a/Core/IO/ModuleInstaller.cs
+++ b/Core/IO/ModuleInstaller.cs
@@ -146,7 +146,7 @@ namespace CKAN.IO
             {
                 var gameDir = new DirectoryInfo(instance.GameDir);
                 long modInstallCompletedBytes = 0;
-                foreach (var mod in ModsInDependencyOrder(resolver, cached, downloads, downloader))
+                foreach (var mod in ModsInDependencyOrder(resolver, cached, new HashSet<CkanModule>(), downloads, downloader))
                 {
                     // Re-check that there's enough free space in case game dir and cache are on same drive
                     CKANPathUtils.CheckFreeSpace(gameDir, mod.install_size,
@@ -184,20 +184,21 @@ namespace CKAN.IO
 
         private static IEnumerable<CkanModule> ModsInDependencyOrder(RelationshipResolver            resolver,
                                                                      IReadOnlyCollection<CkanModule> cached,
+                                                                     ISet<CkanModule>                done,
                                                                      IReadOnlyCollection<CkanModule> toDownload,
                                                                      IDownloader?                    downloader)
 
-            => ModsInDependencyOrder(resolver, cached,
+            => ModsInDependencyOrder(resolver, cached, done,
                                      downloader != null && toDownload.Count > 0
                                          ? downloader.ModulesAsTheyFinish(cached, toDownload)
                                          : null);
 
         private static IEnumerable<CkanModule> ModsInDependencyOrder(RelationshipResolver            resolver,
                                                                      IReadOnlyCollection<CkanModule> cached,
+                                                                     ISet<CkanModule>                done,
                                                                      IEnumerable<CkanModule>?        downloading)
         {
             var waiting = new HashSet<CkanModule>();
-            var done    = new HashSet<CkanModule>();
             if (downloading != null)
             {
                 foreach (var newlyCached in downloading)
@@ -211,6 +212,7 @@ namespace CKAN.IO
             }
             else
             {
+                // With no downloading sequence, we're only going to return cached mods
                 waiting.UnionWith(cached);
                 // Treat excluded mods as already done
                 done.UnionWith(resolver.ModList().Except(waiting));
@@ -229,8 +231,8 @@ namespace CKAN.IO
         }
 
         private static IEnumerable<CkanModule> OnePass(RelationshipResolver resolver,
-                                                       HashSet<CkanModule>  waiting,
-                                                       HashSet<CkanModule>  done)
+                                                       ISet<CkanModule>     waiting,
+                                                       ISet<CkanModule>     done)
         {
             while (true)
             {
@@ -1187,6 +1189,7 @@ namespace CKAN.IO
         /// <param name="add">Modules to add</param>
         /// <param name="autoInstalled">true or false for each item in `add`</param>
         /// <param name="remove">Modules to remove</param>
+        /// <param name="skipFiles">Modules that have been reregistered without file changes</param>
         /// <param name="downloader">Downloader to use</param>
         /// <param name="deduper">Deduplicator to use</param>
         /// <param name="enforceConsistency">Whether to enforce consistency</param>
@@ -1196,6 +1199,7 @@ namespace CKAN.IO
                                IReadOnlyCollection<CkanModule>      add,
                                ISet<CkanModule>                     autoInstalled,
                                IReadOnlyCollection<InstalledModule> remove,
+                               ISet<CkanModule>                     skipFiles,
                                IDownloader                          downloader,
                                bool                                 enforceConsistency,
                                InstalledFilesDeduplicator?          deduper = null)
@@ -1229,7 +1233,7 @@ namespace CKAN.IO
                                           + installBytes  - installedBytes;
                     User.RaiseProgress(rateCounter);
                 };
-                var toInstall = ModsInDependencyOrder(resolver, cached, toDownload, downloader);
+                var toInstall = ModsInDependencyOrder(resolver, cached, skipFiles, toDownload, downloader);
 
                 long modRemoveCompletedBytes = 0;
                 foreach (var instMod in remove)
@@ -1429,6 +1433,7 @@ namespace CKAN.IO
                       toInstall,
                       autoInstalled,
                       toRemove,
+                      skipFiles ?? new HashSet<CkanModule>(),
                       downloader,
                       enforceConsistency,
                       deduper);
@@ -1531,6 +1536,7 @@ namespace CKAN.IO
                       resolvedModsToInstall,
                       new HashSet<CkanModule>(),
                       modsToRemove,
+                      new HashSet<CkanModule>(),
                       downloader,
                       enforceConsistency,
                       deduper);

--- a/Core/IO/ModuleInstaller.cs
+++ b/Core/IO/ModuleInstaller.cs
@@ -1353,6 +1353,14 @@ namespace CKAN.IO
             // install, but we need to calculate what needs to be removed.
             var toRemove = new List<InstalledModule>();
 
+            if (skipFiles != null)
+            {
+                foreach (var module in skipFiles)
+                {
+                    User.RaiseMessage(Properties.Resources.ModuleInstallerUpgradeReinstalling,
+                                      cache.DescribeAvailability(config, module));
+                }
+            }
             // Let's discover what we need to do with each module!
             foreach (CkanModule module in toInstall)
             {
@@ -1360,29 +1368,8 @@ namespace CKAN.IO
 
                 if (installed_mod == null)
                 {
-                    if (!cache.IsMaybeCachedZip(module)
-                        && cache.GetInProgressFileName(module) is FileInfo inProgressFile)
-                    {
-                        if (inProgressFile.Exists)
-                        {
-                            User.RaiseMessage(Properties.Resources.ModuleInstallerUpgradeInstallingResuming,
-                                              module.name, module.version,
-                                              string.Join(", ", PrioritizedHosts(config, module.download)),
-                                              CkanModule.FmtSize(module.download_size - inProgressFile.Length));
-                        }
-                        else
-                        {
-                            User.RaiseMessage(Properties.Resources.ModuleInstallerUpgradeInstallingUncached,
-                                              module.name, module.version,
-                                              string.Join(", ", PrioritizedHosts(config, module.download)),
-                                              CkanModule.FmtSize(module.download_size));
-                        }
-                    }
-                    else
-                    {
-                        User.RaiseMessage(Properties.Resources.ModuleInstallerUpgradeInstallingCached,
-                                          module.name, module.version);
-                    }
+                    User.RaiseMessage(Properties.Resources.ModuleInstallerUpgradeInstalling,
+                                      cache.DescribeAvailability(config, module));
                 }
                 else
                 {
@@ -1393,38 +1380,19 @@ namespace CKAN.IO
                     if (installed.version.Equals(module.version))
                     {
                         User.RaiseMessage(Properties.Resources.ModuleInstallerUpgradeReinstalling,
-                                          module.name, module.version);
+                                          cache.DescribeAvailability(config, module));
                     }
                     else if (installed.version.IsGreaterThan(module.version))
                     {
                         User.RaiseMessage(Properties.Resources.ModuleInstallerUpgradeDowngrading,
-                                          module.name, installed.version, module.version);
+                                          installed.name, installed.version,
+                                          cache.DescribeAvailability(config, module));
                     }
                     else
                     {
-                        if (!cache.IsMaybeCachedZip(module)
-                            && cache.GetInProgressFileName(module) is FileInfo inProgressFile)
-                        {
-                            if (inProgressFile.Exists)
-                            {
-                                User.RaiseMessage(Properties.Resources.ModuleInstallerUpgradeUpgradingResuming,
-                                                  module.name, installed.version, module.version,
-                                                  string.Join(", ", PrioritizedHosts(config, module.download)),
-                                                  CkanModule.FmtSize(module.download_size - inProgressFile.Length));
-                            }
-                            else
-                            {
-                                User.RaiseMessage(Properties.Resources.ModuleInstallerUpgradeUpgradingUncached,
-                                                  module.name, installed.version, module.version,
-                                                  string.Join(", ", PrioritizedHosts(config, module.download)),
-                                                  CkanModule.FmtSize(module.download_size));
-                            }
-                        }
-                        else
-                        {
-                            User.RaiseMessage(Properties.Resources.ModuleInstallerUpgradeUpgradingCached,
-                                              module.name, installed.version, module.version);
-                        }
+                        User.RaiseMessage(Properties.Resources.ModuleInstallerUpgradeUpgrading,
+                                          installed.name, installed.version,
+                                          cache.DescribeAvailability(config, module));
                     }
                 }
             }
@@ -1451,6 +1419,8 @@ namespace CKAN.IO
                 foreach (var module in skipFiles.Intersect(modules))
                 {
                     registry.ReregisterModule(instance, module);
+                    User.RaiseMessage(Properties.Resources.ModuleInstallerInstalledMod,
+                                      $"{module.name} {module.version}");
                 }
             }
             AddRemove(ref possibleConfigOnlyDirs,

--- a/Core/Net/NetAsyncDownloader.DownloadPart.cs
+++ b/Core/Net/NetAsyncDownloader.DownloadPart.cs
@@ -98,7 +98,7 @@ namespace CKAN
                 // Tell the server what kind of files we want
                 if (!string.IsNullOrEmpty(mimeType))
                 {
-                    log.InfoFormat("Setting MIME type {0}", mimeType);
+                    log.DebugFormat("Setting MIME type {0}", mimeType);
                     agent.Headers.Add("Accept", mimeType);
                 }
 

--- a/Core/Net/RedirectingTimeoutWebClient.cs
+++ b/Core/Net/RedirectingTimeoutWebClient.cs
@@ -41,7 +41,7 @@ namespace CKAN
             Headers.Add("User-Agent", userAgent);
             if (!string.IsNullOrEmpty(mimeType))
             {
-                log.InfoFormat("Setting MIME type {0}", mimeType);
+                log.DebugFormat("Setting MIME type {0}", mimeType);
                 Headers.Add("Accept", mimeType);
             }
             if (permanentRedirects.TryGetValue(address, out Uri? redirUri))

--- a/Core/Properties/Resources.fr-FR.resx
+++ b/Core/Properties/Resources.fr-FR.resx
@@ -486,26 +486,17 @@ Remplacer ?</value>
   <data name="ModuleInstallerAboutToUpgrade" xml:space="preserve">
     <value>Vont être mis à jour :</value>
   </data>
-  <data name="ModuleInstallerUpgradeInstallingResuming" xml:space="preserve">
-    <value> * Installation : {0} {1} ({2}, {3} restant)</value>
-  </data>
-  <data name="ModuleInstallerUpgradeInstallingUncached" xml:space="preserve">
-    <value> * Installation : {0} {1} ({2}, {3})</value>
-  </data>
-  <data name="ModuleInstallerUpgradeInstallingCached" xml:space="preserve">
-    <value> * Installation : {0} {1} (en cache)</value>
+  <data name="ModuleInstallerUpgradeInstalling" xml:space="preserve">
+    <value> * Installation : {0}</value>
   </data>
   <data name="ModuleInstallerUpgradeReinstalling" xml:space="preserve">
-    <value> * Réinstallation : {0} {1}</value>
+    <value> * Réinstallation : {0}</value>
   </data>
   <data name="ModuleInstallerUpgradeDowngrading" xml:space="preserve">
     <value> * Rétrogradation : {0} de {1} vers {2}</value>
   </data>
-  <data name="ModuleInstallerUpgradeUpgradingUncached" xml:space="preserve">
-    <value> * Mise à jour : {0} {1} vers {2} ({3}, {4})</value>
-  </data>
-  <data name="ModuleInstallerUpgradeUpgradingCached" xml:space="preserve">
-    <value> * Mise à jour : {0} {1} vers {2} (en cache)</value>
+  <data name="ModuleInstallerUpgradeUpgrading" xml:space="preserve">
+    <value> * Mise à jour : {0} {1} vers {2}</value>
   </data>
   <data name="ModuleInstallerUpgradeAutoRemoving" xml:space="preserve">
     <value> * Suppression automatique : {0} {1}</value>
@@ -633,7 +624,7 @@ Consultez cette page pour obtenir de l'aide :
   <data name="KrakenAlreadyRunning" xml:space="preserve">
     <value>Fichier verrou avec un ID de processus actif à {0}
 
-Un autre processus CKAN est probablement déjà en train d'accéder à ce dossier de jeu. Si vous êtes sûr que ce fichier verrou est périmé, vous pouvez supprimer ce fichier pour continuer. Mais si ce n'est pas le cas, les deux CKAN risque de rentrer en conflit et corrompre votre registre de mods et votre dossier de jeu. 
+Un autre processus CKAN est probablement déjà en train d'accéder à ce dossier de jeu. Si vous êtes sûr que ce fichier verrou est périmé, vous pouvez supprimer ce fichier pour continuer. Mais si ce n'est pas le cas, les deux CKAN risque de rentrer en conflit et corrompre votre registre de mods et votre dossier de jeu.
 
 Voulez-vous supprimez ce fichier verrou pour forcer l'accès ?</value>
   </data>
@@ -722,9 +713,6 @@ Libérez de l'espace sur cet appareil ou modifiez vos paramètres pour utiliser 
   </data>
   <data name="NetModuleCacheModuleResuming" xml:space="preserve">
     <value>{0} {1} ({2}, {3} restant)</value>
-  </data>
-  <data name="ModuleInstallerUpgradeUpgradingResuming" xml:space="preserve">
-    <value> * Mise à jour : {0} {1} vers {2} ({3}, {4} restant)</value>
   </data>
   <data name="ModpackName" xml:space="preserve">
     <value>installé-{0}</value>

--- a/Core/Properties/Resources.it-IT.resx
+++ b/Core/Properties/Resources.it-IT.resx
@@ -456,26 +456,17 @@ Sovrascrivere?</value>
   <data name="ModuleInstallerAboutToUpgrade" xml:space="preserve">
     <value>Stai per aggiornare:</value>
   </data>
-  <data name="ModuleInstallerUpgradeInstallingResuming" xml:space="preserve">
-    <value> * Installa: {0} {1} ({2}, {3} rimanenti)</value>
-  </data>
-  <data name="ModuleInstallerUpgradeInstallingUncached" xml:space="preserve">
-    <value> * Installa: {0} {1} ({2}, {3} rimanenti)</value>
-  </data>
-  <data name="ModuleInstallerUpgradeInstallingCached" xml:space="preserve">
-    <value> * Installazione: {0} {1} (in cache)</value>
+  <data name="ModuleInstallerUpgradeInstalling" xml:space="preserve">
+    <value> * Installa: {0}</value>
   </data>
   <data name="ModuleInstallerUpgradeReinstalling" xml:space="preserve">
-    <value> * Reinstallazione: {0} {1}</value>
+    <value> * Reinstallazione: {0}</value>
   </data>
   <data name="ModuleInstallerUpgradeDowngrading" xml:space="preserve">
     <value> * Downgrade: {0} da {1} a {2}</value>
   </data>
-  <data name="ModuleInstallerUpgradeUpgradingUncached" xml:space="preserve">
-    <value> * Aggiornamento: {0} {1} a {2} ({3}, {4})</value>
-  </data>
-  <data name="ModuleInstallerUpgradeUpgradingCached" xml:space="preserve">
-    <value> * Aggiornamento: {0} {1} a {2} (in cache)</value>
+  <data name="ModuleInstallerUpgradeUpgrading" xml:space="preserve">
+    <value> * Aggiornamento: {0} {1} a {2}</value>
   </data>
   <data name="ModuleInstallerUpgradeAutoRemoving" xml:space="preserve">
     <value> * Rimozione automatica: {0} {1}</value>
@@ -701,9 +692,6 @@ Libera spazio su quel dispositivo o modifica le impostazioni per utilizzare un'a
   </data>
   <data name="NetModuleCacheModuleResuming" xml:space="preserve">
     <value>{0} {1} ({2}, {3} rimanenti)</value>
-  </data>
-  <data name="ModuleInstallerUpgradeUpgradingResuming" xml:space="preserve">
-    <value> * Aggiorna: {0} {1} a {2} ({3}, {4} rimanenti)</value>
   </data>
   <data name="ModpackName" xml:space="preserve">
     <value>installata-{0}</value>

--- a/Core/Properties/Resources.pl-PL.resx
+++ b/Core/Properties/Resources.pl-PL.resx
@@ -472,26 +472,17 @@ Nadpisać?</value>
   <data name="ModuleInstallerAboutToUpgrade" xml:space="preserve">
     <value>Zaktualizuje:</value>
   </data>
-  <data name="ModuleInstallerUpgradeInstallingResuming" xml:space="preserve">
-    <value> * Instalacja: {0} {1} ({2}, {3} pozostało)</value>
-  </data>
-  <data name="ModuleInstallerUpgradeInstallingUncached" xml:space="preserve">
-    <value> * Instalacja: {0} {1} ({2}, {3} pozostało)</value>
-  </data>
-  <data name="ModuleInstallerUpgradeInstallingCached" xml:space="preserve">
-    <value> * Instalacja: {0} {1} (zapisane na dysku)</value>
+  <data name="ModuleInstallerUpgradeInstalling" xml:space="preserve">
+    <value> * Instalacja: {0}</value>
   </data>
   <data name="ModuleInstallerUpgradeReinstalling" xml:space="preserve">
-    <value> * Zainstaluj ponownie: {0} {1}</value>
+    <value> * Zainstaluj ponownie: {0}</value>
   </data>
   <data name="ModuleInstallerUpgradeDowngrading" xml:space="preserve">
     <value> * Downgrade: {0} z {1} do {2}</value>
   </data>
-  <data name="ModuleInstallerUpgradeUpgradingUncached" xml:space="preserve">
-    <value> * Aktualizowanie: {0} {1} do {2} ({3}, {4})</value>
-  </data>
-  <data name="ModuleInstallerUpgradeUpgradingCached" xml:space="preserve">
-    <value> * Aktualizowanie: {0} {1} do {2} (zapisane na dysku)</value>
+  <data name="ModuleInstallerUpgradeUpgrading" xml:space="preserve">
+    <value> * Aktualizowanie: {0} {1} do {2}</value>
   </data>
   <data name="ModuleInstallerUpgradeAutoRemoving" xml:space="preserve">
     <value> * Automatyczne usuwanie: {0} {1}</value>
@@ -711,9 +702,6 @@ Zwolnij miejsce na tym urządzeniu lub zmień ustawienia, aby użyć innej lokal
   </data>
   <data name="NetModuleCacheModuleResuming" xml:space="preserve">
     <value>{0} {1} ({2}, {3} pozostało)</value>
-  </data>
-  <data name="ModuleInstallerUpgradeUpgradingResuming" xml:space="preserve">
-    <value> * Aktualizacja: {0} {1} do {2} ({3}, {4} pozostało)</value>
   </data>
   <data name="ModpackName" xml:space="preserve">
     <value>zainstalowano-{0}</value>

--- a/Core/Properties/Resources.resx
+++ b/Core/Properties/Resources.resx
@@ -248,13 +248,10 @@ Overwrite?</value></data>
   <data name="ModuleInstallerRemovingMod" xml:space="preserve"><value>Removing {0}...</value></data>
   <data name="ModuleInstallerRemovedMod" xml:space="preserve"><value>Finished removing {0}</value></data>
   <data name="ModuleInstallerAboutToUpgrade" xml:space="preserve"><value>About to upgrade:</value></data>
-  <data name="ModuleInstallerUpgradeInstallingResuming" xml:space="preserve"><value> * Install: {0} {1} ({2}, {3} remaining)</value></data>
-  <data name="ModuleInstallerUpgradeInstallingUncached" xml:space="preserve"><value> * Install: {0} {1} ({2}, {3})</value></data>
-  <data name="ModuleInstallerUpgradeInstallingCached" xml:space="preserve"><value> * Install: {0} {1} (cached)</value></data>
-  <data name="ModuleInstallerUpgradeReinstalling" xml:space="preserve"><value> * Re-install: {0} {1}</value></data>
+  <data name="ModuleInstallerUpgradeInstalling" xml:space="preserve"><value> * Install: {0}</value></data>
+  <data name="ModuleInstallerUpgradeReinstalling" xml:space="preserve"><value> * Re-install: {0}</value></data>
   <data name="ModuleInstallerUpgradeDowngrading" xml:space="preserve"><value> * Downgrade: {0} from {1} to {2}</value></data>
-  <data name="ModuleInstallerUpgradeUpgradingUncached" xml:space="preserve"><value> * Upgrade: {0} {1} to {2} ({3}, {4})</value></data>
-  <data name="ModuleInstallerUpgradeUpgradingCached" xml:space="preserve"><value> * Upgrade: {0} {1} to {2} (cached)</value></data>
+  <data name="ModuleInstallerUpgradeUpgrading" xml:space="preserve"><value> * Upgrade: {0} {1} to {2}</value></data>
   <data name="ModuleInstallerUpgradeAutoRemoving" xml:space="preserve"><value> * Auto-remove: {0} {1}</value></data>
   <data name="ModuleInstallerUpgradeUserDeclined" xml:space="preserve"><value>User declined upgrade list</value></data>
   <data name="ModuleInstallerReplaceAutodetected" xml:space="preserve"><value>Can't replace {0} as it was not installed by CKAN.
@@ -367,7 +364,6 @@ Free up space on that device or change your settings to use another location.
   <data name="NetModuleCacheModuleCached" xml:space="preserve"><value>{0} {1} (cached)</value></data>
   <data name="NetModuleCacheModuleHostSize" xml:space="preserve"><value>{0} {1} ({2}, {3})</value></data>
   <data name="NetModuleCacheModuleResuming" xml:space="preserve"><value>{0} {1} ({2}, {3} remaining)</value></data>
-  <data name="ModuleInstallerUpgradeUpgradingResuming" xml:space="preserve"><value> * Upgrade: {0} {1} to {2} ({3}, {4} remaining)</value></data>
   <data name="ModpackName" xml:space="preserve"><value>installed-{0}</value></data>
   <data name="InstalledModuleToString" xml:space="preserve"><value>{0} (installed {1})</value></data>
   <data name="InstalledModuleToStringAutoInstalled" xml:space="preserve"><value>{0} (installed {1}, auto-installed)</value></data>

--- a/Core/Properties/Resources.ru-RU.resx
+++ b/Core/Properties/Resources.ru-RU.resx
@@ -425,26 +425,17 @@
   <data name="ModuleInstallerAboutToUpgrade" xml:space="preserve">
     <value>Будут обновлены:</value>
   </data>
-  <data name="ModuleInstallerUpgradeInstallingResuming" xml:space="preserve">
-    <value> * Установка: {0} {1} ({2}, {3} осталось)</value>
-  </data>
-  <data name="ModuleInstallerUpgradeInstallingUncached" xml:space="preserve">
-    <value> * Установка: {0} {1} ({2}, {3})</value>
-  </data>
-  <data name="ModuleInstallerUpgradeInstallingCached" xml:space="preserve">
-    <value> * Установка: {0} {1} (кэшировано)</value>
+  <data name="ModuleInstallerUpgradeInstalling" xml:space="preserve">
+    <value> * Установка: {0}</value>
   </data>
   <data name="ModuleInstallerUpgradeReinstalling" xml:space="preserve">
-    <value> * Переустановка: {0} {1}</value>
+    <value> * Переустановка: {0}</value>
   </data>
   <data name="ModuleInstallerUpgradeDowngrading" xml:space="preserve">
     <value> * Откат: {0} от {1} к {2}</value>
   </data>
-  <data name="ModuleInstallerUpgradeUpgradingUncached" xml:space="preserve">
-    <value> * Обновление: {0} {1} до {2} ({3}, {4})</value>
-  </data>
-  <data name="ModuleInstallerUpgradeUpgradingCached" xml:space="preserve">
-    <value> * Обновление: {0} {1} до {2} (кэшировано)</value>
+  <data name="ModuleInstallerUpgradeUpgrading" xml:space="preserve">
+    <value> * Обновление: {0} {1} до {2}</value>
   </data>
   <data name="ModuleInstallerUpgradeUserDeclined" xml:space="preserve">
     <value>Пользователь отменил список обновления</value>
@@ -628,9 +619,6 @@ https://github.com/KSP-CKAN/CKAN/wiki/SSL-certificate-errors</value>
   </data>
   <data name="NetModuleCacheModuleResuming" xml:space="preserve">
     <value>{0} {1} ({2}, {3} осталось)</value>
-  </data>
-  <data name="ModuleInstallerUpgradeUpgradingResuming" xml:space="preserve">
-    <value> * Обновление: {0} {1} до {2} ({3}, {4} осталось)</value>
   </data>
   <data name="ModpackName" xml:space="preserve">
     <value>установлено-{0}</value>

--- a/Core/Properties/Resources.zh-CN.resx
+++ b/Core/Properties/Resources.zh-CN.resx
@@ -486,26 +486,17 @@
   <data name="ModuleInstallerAboutToUpgrade" xml:space="preserve">
     <value>中止升级:</value>
   </data>
-  <data name="ModuleInstallerUpgradeInstallingResuming" xml:space="preserve">
-    <value> * 安装: {0} {1} ({2}, {3} 剩余)</value>
-  </data>
-  <data name="ModuleInstallerUpgradeInstallingUncached" xml:space="preserve">
-    <value> * 安装: {0} {1} ({2}，{3})</value>
-  </data>
-  <data name="ModuleInstallerUpgradeInstallingCached" xml:space="preserve">
-    <value> * 安装: {0} {1} (已缓存)</value>
+  <data name="ModuleInstallerUpgradeInstalling" xml:space="preserve">
+    <value> * 安装: {0}</value>
   </data>
   <data name="ModuleInstallerUpgradeReinstalling" xml:space="preserve">
-    <value> * 重新安装: {0} {1}</value>
+    <value> * 重新安装: {0}</value>
   </data>
   <data name="ModuleInstallerUpgradeDowngrading" xml:space="preserve">
     <value> * 降级: {0} 从 {1} 到 {2}</value>
   </data>
-  <data name="ModuleInstallerUpgradeUpgradingUncached" xml:space="preserve">
-    <value> * 升级: {0} {1} 到 {2} ({3}，{4})</value>
-  </data>
-  <data name="ModuleInstallerUpgradeUpgradingCached" xml:space="preserve">
-    <value> * 升级: {0} {1} 到 {2} (已缓存)</value>
+  <data name="ModuleInstallerUpgradeUpgrading" xml:space="preserve">
+    <value> * 升级: {0} {1} 到 {2}</value>
   </data>
   <data name="ModuleInstallerUpgradeAutoRemoving" xml:space="preserve">
     <value> * 自动移除: {0} {1}</value>
@@ -725,9 +716,6 @@ Owning Mod(已有Mod): {2}</value>
   </data>
   <data name="NetModuleCacheModuleResuming" xml:space="preserve">
     <value>{0} {1} ({2}, {3} 剩余)</value>
-  </data>
-  <data name="ModuleInstallerUpgradeUpgradingResuming" xml:space="preserve">
-    <value> * 升级: {0} {1} 到 {2} ({3}, {4} 剩余)</value>
   </data>
   <data name="ModpackName" xml:space="preserve">
     <value>已安装-{0}</value>

--- a/Core/Registry/CompatibilitySorter.cs
+++ b/Core/Registry/CompatibilitySorter.cs
@@ -119,7 +119,7 @@ namespace CKAN
         /// <returns>
         /// Mapping from identifiers to compatible mods providing those identifiers
         /// </returns>
-        private static Dictionary<string, HashSet<AvailableModule>> CompatibleProviders(
+        private Dictionary<string, HashSet<AvailableModule>> CompatibleProviders(
                 GameVersionCriteria                    crit,
                 IDictionary<string, AvailableModule[]> providers)
             => providers
@@ -129,12 +129,14 @@ namespace CKAN
                     kvp.Value.Where(availMod => availMod.AllAvailable()
                                                         .Any(ckm => !ckm.IsDLC
                                                                     && ckm.ProvidesList.Contains(kvp.Key)
-                                                                    && ckm.IsCompatible(crit)))
+                                                                    && ckm.IsCompatible(crit)
+                                                                    && ckm.release_status <= (StabilityTolerance.ModStabilityTolerance(ckm.identifier)
+                                                                                              ?? StabilityTolerance.OverallStabilityTolerance)))
                              .ToHashSet()))
                 .Where(kvp => kvp.Value.Count > 0)
                 .ToDictionary();
 
-        private IEnumerable<Tuple<bool?, ConcurrentDictionary<string, AvailableModule>>> getCompatGroups(
+        private ParallelQuery<Tuple<bool?, ConcurrentDictionary<string, AvailableModule>>> getCompatGroups(
                 IEnumerable<Dictionary<string, AvailableModule>> available)
             // Merge AvailableModules with duplicate identifiers
             => available.SelectMany(dict => dict)
@@ -145,7 +147,9 @@ namespace CKAN
                         // Group into trivially [in]compatible (false/true) and indeterminate (null)
                         .AsParallel()
                         .GroupBy(kvp => kvp.Value.AllAvailable()
-                                                 .All(m => !m.IsCompatible(CompatibleVersions))
+                                                 .All(m => !m.IsCompatible(CompatibleVersions)
+                                                           || (m.release_status > (StabilityTolerance.ModStabilityTolerance(m.identifier)
+                                                                                   ?? StabilityTolerance.OverallStabilityTolerance)))
                                             // No versions compatible == incompatible
                                             ? false
                                             : kvp.Value.AllAvailable()
@@ -176,7 +180,9 @@ namespace CKAN
                 return;
             }
             investigating.Push(identifier);
-            foreach (CkanModule m in am.AllAvailable().Where(m => m.IsCompatible(CompatibleVersions)))
+            foreach (var m in am.AllAvailable().Where(m => m.IsCompatible(CompatibleVersions)
+                                                           && m.release_status <= (StabilityTolerance.ModStabilityTolerance(m.identifier)
+                                                                                   ?? StabilityTolerance.OverallStabilityTolerance)))
             {
                 log.DebugFormat("What about {0}?", m.version);
                 bool installable = true;

--- a/Core/Registry/CompatibilitySorter.cs
+++ b/Core/Registry/CompatibilitySorter.cs
@@ -87,15 +87,11 @@ namespace CKAN
         public readonly StabilityToleranceConfig StabilityTolerance;
 
         public IReadOnlyCollection<CkanModule> LatestCompatible
-        {
-            get
-            {
-                latestCompatible ??= Compatible.Values.Select(avail => avail.Latest(StabilityTolerance, CompatibleVersions))
-                                                      .OfType<CkanModule>()
-                                                      .ToList();
-                return latestCompatible;
-            }
-        }
+            => latestCompatible ??= Compatible.Values
+                                              .Select(avail => avail.Latest(StabilityTolerance,
+                                                                            CompatibleVersions))
+                                              .OfType<CkanModule>()
+                                              .ToArray();
 
         /// <summary>
         /// Mods that are incompatible with our versions
@@ -103,22 +99,17 @@ namespace CKAN
         public readonly ConcurrentDictionary<string, AvailableModule> Incompatible;
 
         public IReadOnlyCollection<CkanModule> LatestIncompatible
-        {
-            get
-            {
-                latestIncompatible ??= Incompatible.Values.Select(avail => avail.Latest(StabilityTolerance))
-                                                          .OfType<CkanModule>()
-                                                          .ToList();
-                return latestIncompatible;
-            }
-        }
+            => latestIncompatible ??= Incompatible.Values
+                                                  .Select(avail => avail.Latest(StabilityTolerance))
+                                                  .OfType<CkanModule>()
+                                                  .ToArray();
 
         private readonly IDictionary<string, InstalledModule>        installed;
         private readonly IReadOnlyCollection<string>                 dlls;
         private readonly IDictionary<string, UnmanagedModuleVersion> dlc;
 
-        private List<CkanModule>? latestCompatible;
-        private List<CkanModule>? latestIncompatible;
+        private IReadOnlyCollection<CkanModule>? latestCompatible;
+        private IReadOnlyCollection<CkanModule>? latestIncompatible;
 
         /// <summary>
         /// Filter the provides mapping by compatibility
@@ -129,8 +120,8 @@ namespace CKAN
         /// Mapping from identifiers to compatible mods providing those identifiers
         /// </returns>
         private static Dictionary<string, HashSet<AvailableModule>> CompatibleProviders(
-            GameVersionCriteria                    crit,
-            IDictionary<string, AvailableModule[]> providers)
+                GameVersionCriteria                    crit,
+                IDictionary<string, AvailableModule[]> providers)
             => providers
                 .AsParallel()
                 .Select(kvp => new KeyValuePair<string, HashSet<AvailableModule>>(
@@ -144,7 +135,7 @@ namespace CKAN
                 .ToDictionary();
 
         private IEnumerable<Tuple<bool?, ConcurrentDictionary<string, AvailableModule>>> getCompatGroups(
-            IEnumerable<Dictionary<string, AvailableModule>> available)
+                IEnumerable<Dictionary<string, AvailableModule>> available)
             // Merge AvailableModules with duplicate identifiers
             => available.SelectMany(dict => dict)
                         .GroupBy(kvp => kvp.Key,
@@ -194,7 +185,7 @@ namespace CKAN
                     foreach (RelationshipDescriptor rel in m.depends)
                     {
                         bool foundCompat = false;
-                        if (rel.MatchesAny(installed.Select(kvp => kvp.Value.Module).ToList(), dlls, dlc))
+                        if (rel.MatchesAny(installed.Select(kvp => kvp.Value.Module).ToArray(), dlls, dlc))
                         {
                             // Matches a DLL or DLC, cool
                             foundCompat = true;

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -334,6 +334,7 @@ namespace CKAN
             }
             foreach (var ident in remainingIdents)
             {
+                var imod = querier.GetInstalledVersion(ident);
                 var otherIdents = remainingIdents.Where(i => i != ident)
                                                  .ToArray();
                 // Have to check HasUpdate again to account for the additions to partialSolution
@@ -354,12 +355,17 @@ namespace CKAN
                     {
                         yield return solution;
                     }
+                    if (imod == latest)
+                    {
+                        log.DebugFormat("Update for {0} is a re-install, skipping installed branch",
+                                        imod);
+                        continue;
+                    }
                 }
 
                 foreach (var solution in querier.FindUpgradeabilitySolutions(
                                              instance, otherIdents,
-                                             querier.GetInstalledVersion(ident)
-                                             is { IsDLC: false } imod
+                                             imod is { IsDLC: false }
                                                  ? partialSolution.Append((false, imod))
                                                                   .ToArray()
                                                  : partialSolution,

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -432,11 +432,11 @@ namespace CKAN
                                                     IGame                 game,
                                                     string                identifier)
         {
-            List<CkanModule>? releases = null;
+            CkanModule[]? releases = null;
             try
             {
                 releases = querier.AvailableByIdentifier(identifier)
-                                  .ToList();
+                                  .ToArray();
             }
             catch
             {
@@ -444,10 +444,10 @@ namespace CKAN
                 if (instMod != null)
                 {
                     releases = Enumerable.Repeat(instMod.Module, 1)
-                                         .ToList();
+                                         .ToArray();
                 }
             }
-            if (releases != null && releases.Count > 0)
+            if (releases is { Length: > 0 })
             {
                 CkanModule.GetMinMaxVersions(releases, out _, out _,
                                              out GameVersion? minKsp, out GameVersion? maxKsp);

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -312,9 +312,20 @@ namespace CKAN
                                                                                      module:      m)))
                                                  .ToArray();
             var partialMods     = partialSolution.Select(tuple => tuple.module).ToArray();
+            if (notUpgradeable.Where(m => !m.DependsAndConflictsOK(partialMods))
+                              .ToArray()
+                is { Length: > 0 } incompatInst)
+            {
+                log.DebugFormat("Installed {0} not compatible with partial solution, rejecting {1}",
+                                string.Join(", ", incompatInst.Select(m => m.ToString())),
+                                string.Join(", ", partialSolution.Select(m => m.ToString())));
+                yield break;
+            }
 
             if (remainingIdents.Length == 0)
             {
+                log.DebugFormat("Validating upgradability solution: {0}",
+                                string.Join(", ", partialSolution.Select(m => m.ToString())));
                 // We are a leaf node, return whatever we received if it is a valid solution
                 if (partialSolution.All(tuple => !tuple.upgradeable)
                     || Utilities.DefaultIfThrows(() =>
@@ -361,6 +372,13 @@ namespace CKAN
                                         imod);
                         continue;
                     }
+                }
+
+                if (imod is { IsDLC: false} && !imod.DependsAndConflictsOK(partialMods))
+                {
+                    log.DebugFormat("Installed {0} not compatible with partial solution, rejecting installed branch",
+                                    imod);
+                    continue;
                 }
 
                 foreach (var solution in querier.FindUpgradeabilitySolutions(

--- a/Core/Registry/Registry.cs
+++ b/Core/Registry/Registry.cs
@@ -1166,14 +1166,13 @@ namespace CKAN
             IDictionary<string, UnmanagedModuleVersion> dlc,
             Func<RelationshipDescriptor, bool>?         satisfiedFilter = null)
         {
-            log.DebugFormat("Finding reverse dependencies of: {0}", string.Join(", ", modulesToRemove));
-            log.DebugFormat("From installed mods: {0}", string.Join(", ", origInstalled));
-            log.DebugFormat("Installing mods: {0}", string.Join(", ", modulesToInstall));
-
             // The empty list has no reverse dependencies
             // (Don't remove broken modules if we're only installing)
             if (modulesToRemove.Count != 0)
             {
+                log.DebugFormat("Finding reverse dependencies of: {0}", string.Join(", ", modulesToRemove));
+                log.DebugFormat("From installed mods: {0}", string.Join(", ", origInstalled));
+                log.DebugFormat("Installing mods: {0}", string.Join(", ", modulesToInstall));
                 // All modules in the input are included in the output
                 foreach (var starter in modulesToRemove)
                 {

--- a/Core/Relationships/RelationshipResolver.cs
+++ b/Core/Relationships/RelationshipResolver.cs
@@ -481,8 +481,8 @@ namespace CKAN
                              // Resolve ties in name order
                              .ThenBy(m => m.name);
 
-        public bool ReadyToInstall(CkanModule                      mod,
-                                   IReadOnlyCollection<CkanModule> installed)
+        public bool ReadyToInstall(CkanModule       mod,
+                                   ISet<CkanModule> installed)
             => !modlist.Values.Distinct()
                               .Where(m => m != mod)
                               .Except(installed)

--- a/Core/Types/CkanModule.cs
+++ b/Core/Types/CkanModule.cs
@@ -572,6 +572,12 @@ namespace CKAN
                 && (ReferenceEquals(this, obj)
                     || (obj.GetType() == GetType() && Equals((CkanModule)obj)));
 
+        public static bool operator ==(CkanModule? m1, CkanModule? m2)
+            => Equals(m1, m2);
+
+        public static bool operator !=(CkanModule? m1, CkanModule? m2)
+            => !Equals(m1, m2);
+
         public bool MetadataEquals(CkanModule other, out bool installedFilesChanged)
         {
             installedFilesChanged = true;

--- a/GUI/Controls/ManageMods.Designer.cs
+++ b/GUI/Controls/ManageMods.Designer.cs
@@ -442,7 +442,7 @@ namespace CKAN.GUI
             this.InstalledVersion.Name = "InstalledVersion";
             this.InstalledVersion.ReadOnly = true;
             this.InstalledVersion.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            this.InstalledVersion.Width = 70;
+            this.InstalledVersion.Width = 90;
             resources.ApplyResources(this.InstalledVersion, "InstalledVersion");
             //
             // LatestVersion
@@ -451,7 +451,7 @@ namespace CKAN.GUI
             this.LatestVersion.Name = "LatestVersion";
             this.LatestVersion.ReadOnly = true;
             this.LatestVersion.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            this.LatestVersion.MinimumWidth = 70;
+            this.LatestVersion.MinimumWidth = 90;
             resources.ApplyResources(this.LatestVersion, "LatestVersion");
             //
             // GameCompatibility

--- a/GUI/Controls/ModInfo/Relationships.cs
+++ b/GUI/Controls/ModInfo/Relationships.cs
@@ -79,7 +79,7 @@ namespace CKAN.GUI
         private static bool ImMyOwnGrandpa(TreeNode node)
             => node.Tag is CkanModule module
                && (node.Parent?.TraverseNodes(nd => nd.Parent)
-                               .Any(other => other.Tag == module)
+                               .Any(other => module.Equals(other.Tag))
                               ?? false);
 
         private void ReverseRelationshipsCheckbox_Click(object? sender, EventArgs? e)

--- a/GUI/Dialogs/SettingsDialog.cs
+++ b/GUI/Dialogs/SettingsDialog.cs
@@ -699,13 +699,12 @@ namespace CKAN.GUI
 
         #region CKAN updates
 
-        private void UpdateAutoUpdate()
+        private void UpdateAutoUpdate(bool bypassCache = false)
         {
             LocalVersionLabel.Text = Meta.GetVersion();
             try
             {
-                if (updater.GetUpdate(coreConfig.DevBuilds ?? false,
-                                      userAgent)
+                if (updater.GetUpdate(coreConfig.DevBuilds ?? false, bypassCache)
                            .Version
                     is CkanModuleVersion latestVersion)
                 {
@@ -728,7 +727,7 @@ namespace CKAN.GUI
         {
             try
             {
-                UpdateAutoUpdate();
+                UpdateAutoUpdate(true);
             }
             catch (Exception exc)
             {

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -719,6 +719,7 @@ namespace CKAN.GUI
 
             var installed = registry_manager.registry.InstalledModules.Select(inst => inst.Module).ToList();
             var toInstall = new List<CkanModule>();
+            bool? overrideVersions = null;
             foreach (string path in files)
             {
                 CkanModule module;
@@ -728,6 +729,21 @@ namespace CKAN.GUI
                     module = CkanModule.FromFile(path);
                     if (module.IsMetapackage && module.depends != null)
                     {
+                        if (module.depends.OfType<ModuleRelationshipDescriptor>()
+                                  .Where(rel => rel.version != null)
+                                  .ToArray()
+                            is { Length: > 0 } versionSpecificRels)
+                        {
+                            if (overrideVersions ??= YesNoDialog(Properties.Resources.MetapackageRelationshipVersionsPrompt,
+                                                                 Properties.Resources.MetapackagePurgeRelationshipVersions,
+                                                                 Properties.Resources.MetapackageKeepRelationshipVersions))
+                            {
+                                foreach (var rel in versionSpecificRels)
+                                {
+                                    rel.version = null;
+                                }
+                            }
+                        }
                         // Add metapackage dependencies to the changeset so we can skip compat checks for them
                         toInstall.AddRange(module.depends
                             .Where(rel => !rel.MatchesAny(installed, null, null))
@@ -761,9 +777,8 @@ namespace CKAN.GUI
                 }
             }
 
-            var modpacks = toInstall.Where(m => m.IsMetapackage)
-                                    .ToArray();
-            if (modpacks is { Length: > 0 })
+            if (toInstall.Where(m => m.IsMetapackage).ToArray()
+                is { Length: > 0 } modpacks)
             {
                 CkanModule.GetMinMaxVersions(modpacks,
                                              out _, out _,
@@ -772,15 +787,15 @@ namespace CKAN.GUI
                                                       maxGame ?? GameVersion.Any);
                 var instRanges = crit.Versions.Select(gv => gv.ToVersionRange())
                                               .ToList();
-                var missing = CurrentInstance.Game
-                                             .KnownVersions
-                                             .Where(gv => filesRange.Contains(gv)
-                                                          && !instRanges.Any(ir => ir.Contains(gv)))
-                                             // Use broad Major.Minor group for each specific version
-                                             .Select(gv => new GameVersion(gv.Major, gv.Minor))
-                                             .Distinct()
-                                             .ToList();
-                if (missing.Count != 0
+                if (CurrentInstance.Game
+                                   .KnownVersions
+                                   .Where(gv => filesRange.Contains(gv)
+                                                && !instRanges.Any(ir => ir.Contains(gv)))
+                                   // Use broad Major.Minor group for each specific version
+                                   .Select(gv => new GameVersion(gv.Major, gv.Minor))
+                                   .Distinct()
+                                   .ToList()
+                    is { Count: > 0 } missing
                     && YesNoDialog(string.Format(Properties.Resources.MetapackageAddCompatibilityPrompt,
                                                  filesRange.ToSummaryString(CurrentInstance.Game),
                                                  crit.ToSummaryString(CurrentInstance.Game)),

--- a/GUI/Main/Main.cs
+++ b/GUI/Main/Main.cs
@@ -37,7 +37,7 @@ namespace CKAN.GUI
         public GameInstance? CurrentInstance => Manager.CurrentInstance;
         private readonly RepositoryDataManager repoData;
         private readonly string? userAgent;
-        private readonly AutoUpdate updater = new AutoUpdate();
+        private readonly AutoUpdate updater;
         public bool Waiting => Wait.Busy;
 
         // Stuff we set when the game instance changes
@@ -129,6 +129,7 @@ namespace CKAN.GUI
             ModInfo.ModuleDoubleClicked += ManageMods.ResetFilterAndSelectModOnList;
             repoData = ServiceLocator.Container.Resolve<RepositoryDataManager>();
             this.userAgent = userAgent;
+            updater = new AutoUpdate(userAgent);
 
             Instance = this;
 

--- a/GUI/Main/MainAutoUpdate.cs
+++ b/GUI/Main/MainAutoUpdate.cs
@@ -50,8 +50,7 @@ namespace CKAN.GUI
                 {
                     log.Info("Making auto-update call");
                     var mainConfig = ServiceLocator.Container.Resolve<IConfiguration>();
-                    var update = updater.GetUpdate(mainConfig.DevBuilds ?? false,
-                                                   userAgent);
+                    var update = updater.GetUpdate(mainConfig.DevBuilds ?? false);
 
                     if (update.Version is CkanModuleVersion latestVersion
                         && !latestVersion.SameClientVersion(Meta.ReleaseVersion))
@@ -85,7 +84,7 @@ namespace CKAN.GUI
             DisableMainWindow();
             tabController.RenameTab(WaitTabPage.Name, Properties.Resources.MainUpgradingWaitTitle);
             var mainConfig = ServiceLocator.Container.Resolve<IConfiguration>();
-            var update = updater.GetUpdate(mainConfig.DevBuilds ?? false, userAgent);
+            var update = updater.GetUpdate(mainConfig.DevBuilds ?? false);
             Wait.SetDescription(string.Format(Properties.Resources.MainUpgradingTo,
                                               update.Version));
 

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -105,22 +105,22 @@ namespace CKAN.GUI
                                                                   .ToHashSet(),
                                                          allLabels.IgnoreMissingIdentifiers(inst)
                                                                   .ToHashSet())
-                       .Select(tuple => registry.IsAutodetected(tuple.Item2.identifier)
-                                            ? new GUIMod(tuple.Item2, repoData, registry,
+                       .Select(tuple => registry.IsAutodetected(tuple.module.identifier)
+                                            ? new GUIMod(tuple.module, repoData, registry,
                                                          inst.StabilityToleranceConfig,
                                                          inst, cache, null,
                                                          hideEpochs, hideV)
                                               {
-                                                  HasUpdate = tuple.Item1,
+                                                  HasUpdate = tuple.upgradeable,
                                               }
-                                            : registry.InstalledModule(tuple.Item2.identifier)
+                                            : registry.InstalledModule(tuple.module.identifier)
                                               is InstalledModule found
                                                   ? new GUIMod(found, repoData, registry,
                                                                inst.StabilityToleranceConfig,
                                                                inst, cache, null,
                                                                hideEpochs, hideV)
                                                     {
-                                                        HasUpdate = tuple.Item1,
+                                                        HasUpdate = tuple.upgradeable,
                                                     }
                                                   : null)
                        .OfType<GUIMod>()

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -210,6 +210,11 @@ Do you want to add the additional versions to this game instance's compatibility
 {0}
 
 Are you sure you want to install them? Cancelling will abort the entire installation.</value></data>
+  <data name="MetapackageRelationshipVersionsPrompt" xml:space="preserve"><value>Some of your chosen modpacks require certain specific versions of mods, rather than allowing all versions. If you leave it like that, you may miss out on updates for those mods. Overriding this is recommended.
+
+Do you want to override the specific-version requirements?</value></data>
+  <data name="MetapackagePurgeRelationshipVersions" xml:space="preserve"><value>Allow any mod versions</value></data>
+  <data name="MetapackageKeepRelationshipVersions" xml:space="preserve"><value>Keep the mod version requirements</value></data>
   <data name="MainChangesetUpdateSelected" xml:space="preserve"><value>Update selected by user to version {0}.</value></data>
   <data name="MainChangesetReinstallMetadataChanged" xml:space="preserve"><value>Re-install (metadata changed)</value></data>
   <data name="MainChangesetReinstallMissing" xml:space="preserve"><value>Re-install (missing folders or files)</value></data>

--- a/Tests/CmdLine/InstallTests.cs
+++ b/Tests/CmdLine/InstallTests.cs
@@ -9,6 +9,7 @@ using CKAN.CmdLine;
 
 using Tests.Data;
 using Tests.Core.Configuration;
+using Tests.Core.Relationships;
 
 namespace Tests.CmdLine
 {
@@ -174,7 +175,7 @@ namespace Tests.CmdLine
                                              return answer;
                                          });
             using (var inst     = new DisposableKSP())
-            using (var repo     = new TemporaryRepository(Core.Relationships.RelationshipResolverTests.MergeWithDefaults(
+            using (var repo     = new TemporaryRepository(RelationshipResolverTests.MergeWithDefaults(
                                       @"{
                                           ""identifier"": ""InstallingMod"",
                                           ""depends"":    [ { ""name"": ""Virtual"" } ],

--- a/Tests/Core/IO/ModuleInstallerTests.cs
+++ b/Tests/Core/IO/ModuleInstallerTests.cs
@@ -1902,7 +1902,7 @@ namespace Tests.Core.IO
                 HashSet<string>? possibleConfigOnlyDirs = null;
                 installer.Upgrade(new CkanModule[] { module },
                                   new NetAsyncModulesDownloader(nullUser, cache),
-                                  ref possibleConfigOnlyDirs,regMgr,
+                                  ref possibleConfigOnlyDirs, regMgr,
                                   null, null,
                                   new HashSet<CkanModule> { module });
 
@@ -1915,6 +1915,64 @@ namespace Tests.Core.IO
                                                new DirectoryInfo(gameDataPath).EnumerateFileSystemInfos()
                                                                               .Select(fsi => fsi.FullName)
                                                                               .Select(CKANPathUtils.NormalizePath));
+            }
+        }
+
+        [Test]
+        public void Upgrade_WithSkipFiles_DependingModsUpgraded()
+        {
+            // Arrange
+            using (var inst     = new DisposableKSP())
+            using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
+            using (var cacheDir = new TemporaryDirectory())
+            using (var cache    = new NetModuleCache(cacheDir))
+            using (var server   = DogeCoinFlagServer())
+            using (var repo     = new TemporaryRepository(RelationshipResolverTests.MergeWithDefaults(
+                                      @"{
+                                          ""identifier"": ""A"",
+                                          ""version"":    ""1.0""
+                                      }",
+                                      @"{
+                                          ""identifier"": ""B"",
+                                          ""version"":    ""1.0"",
+                                          ""depends"": [ { ""name"": ""A"" } ]
+                                      }",
+                                      $@"{{
+                                          ""identifier"": ""B"",
+                                          ""version"":    ""2.0"",
+                                          ""depends"": [ {{ ""name"": ""A"" }} ],
+                                          ""install"": [ {{
+                                              ""find"": ""DogeCoinFlag"",
+                                              ""install_to"": ""GameData""
+                                          }} ],
+                                          ""download"":   ""{server.Url}/DogeCoinFlag-1.01.zip""
+                                      }}"
+                                  ).ToArray()))
+            using (var repoData = new TemporaryRepositoryData(nullUser, repo.repo))
+            using (var regMgr   = RegistryManager.Instance(inst.KSP, repoData.Manager,
+                                                           new Repository[] { repo.repo }))
+            {
+                var installer = new ModuleInstaller(inst.KSP, cache, config, nullUser);
+                var registry = regMgr.registry;
+                var ver1 = new ModuleVersion("1.0");
+                var ver2 = new ModuleVersion("2.0");
+                var modA  = registry.GetModuleByVersion("A", ver1)!;
+                var modB1 = registry.GetModuleByVersion("B", ver1)!;
+                var modB2 = registry.GetModuleByVersion("B", ver2)!;
+                registry.RegisterModule(modA,  Array.Empty<string>(), inst.KSP, false);
+                registry.RegisterModule(modB1, Array.Empty<string>(), inst.KSP, false);
+
+                // Act / Assert
+                HashSet<string>? possibleConfigOnlyDirs = null;
+                Assert.DoesNotThrow(() => installer.Upgrade(
+                                              new CkanModule[] { modA, modB2 },
+                                              new NetAsyncModulesDownloader(nullUser, cache),
+                                              ref possibleConfigOnlyDirs, regMgr,
+                                              null, null,
+                                              new HashSet<CkanModule> { modA }));
+
+                // Assert
+                Assert.AreEqual(ver2, registry.InstalledModule("B")!.Module.version);
             }
         }
 

--- a/Tests/Core/IO/ModuleInstallerTests.cs
+++ b/Tests/Core/IO/ModuleInstallerTests.cs
@@ -756,7 +756,7 @@ namespace Tests.Core.IO
         {
             // Arrange
             var crit = new GameVersionCriteria(new GameVersion(1, 12, 5));
-            using (var repo     = new TemporaryRepository(availableModules.Select(Relationships.RelationshipResolverTests.MergeWithDefaults)
+            using (var repo     = new TemporaryRepository(availableModules.Select(RelationshipResolverTests.MergeWithDefaults)
                                                                           .ToArray()))
             using (var repoData = new TemporaryRepositoryData(nullUser, repo.repo))
             using (var inst     = new DisposableKSP())
@@ -806,7 +806,7 @@ namespace Tests.Core.IO
         {
             // Arrange
             var crit = new GameVersionCriteria(new GameVersion(1, 12, 5));
-            using (var repo     = new TemporaryRepository(availableModules.Select(Relationships.RelationshipResolverTests.MergeWithDefaults)
+            using (var repo     = new TemporaryRepository(availableModules.Select(RelationshipResolverTests.MergeWithDefaults)
                                                                           .ToArray()))
             using (var repoData = new TemporaryRepositoryData(nullUser, repo.repo))
             using (var inst     = new DisposableKSP())
@@ -844,7 +844,7 @@ namespace Tests.Core.IO
             // Arrange
             using (var inst     = new DisposableKSP())
             using (var repo     = new TemporaryRepository(
-                                      Relationships.RelationshipResolverTests.MergeWithDefaults(
+                                      RelationshipResolverTests.MergeWithDefaults(
                                           @"{
                                               ""identifier"": ""InstallingMod"",
                                               ""suggests"": [ { ""name"": ""SuggestedMod"" } ]
@@ -904,7 +904,7 @@ namespace Tests.Core.IO
             // Arrange
             using (var inst     = new DisposableKSP())
             using (var repo     = new TemporaryRepository(
-                                      Relationships.RelationshipResolverTests.MergeWithDefaults(
+                                      RelationshipResolverTests.MergeWithDefaults(
                                           @"{
                                               ""identifier"": ""Parallax"",
                                               ""depends"": [ { ""name"": ""ParallaxTextures"" } ]
@@ -1051,7 +1051,7 @@ namespace Tests.Core.IO
         {
             // Arrange
             using (var inst     = new DisposableKSP())
-            using (var repo     = new TemporaryRepository(Relationships.RelationshipResolverTests
+            using (var repo     = new TemporaryRepository(RelationshipResolverTests
                                                                        .MergeWithDefaults(availableModules)
                                                                        .ToArray()))
             using (var repoData = new TemporaryRepositoryData(nullUser, repo.repo))
@@ -2370,7 +2370,7 @@ namespace Tests.Core.IO
             // Arrange
             using (var inst     = new DisposableKSP("TestInstance", new KerbalSpaceProgram2()))
             using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
-            using (var repo     = new TemporaryRepository(Relationships.RelationshipResolverTests.MergeWithDefaults(
+            using (var repo     = new TemporaryRepository(RelationshipResolverTests.MergeWithDefaults(
                                       @"{
                                           ""identifier"": ""SpaceWarp"",
                                           ""install"": [

--- a/Tests/Core/Net/AutoUpdateTests.cs
+++ b/Tests/Core/Net/AutoUpdateTests.cs
@@ -28,7 +28,7 @@ namespace Tests.Core.Net.AutoUpdateTests
                                                   | SecurityProtocolType.Tls13;
             #pragma warning restore SYSLIB0014
 
-            var updater = new AutoUpdate();
+            var updater = new AutoUpdate(null);
             var update  = updater.GetUpdate(devBuild);
 
             // Is is a *really* basic test to just make sure we get release info

--- a/Tests/Core/Registry/CompatibilitySorter.cs
+++ b/Tests/Core/Registry/CompatibilitySorter.cs
@@ -10,56 +10,56 @@ using CKAN.Configuration;
 using CKAN.Versioning;
 
 using Tests.Data;
+using Tests.Core.Relationships;
 
 namespace Tests.Core.Registry
 {
     [TestFixture]
     public class CompatibilitySorterTests
     {
-        [Test,
-            TestCase(new string[]
-                     {
-                         @"{
-                             ""spec_version"":    ""v1.4"",
-                             ""identifier"":      ""kOS-EVA"",
-                             ""name"":            ""kOS-EVA"",
-                             ""abstract"":        ""Addon for kOS that allows controlling a kerbal while on EVA"",
-                             ""version"":         ""0.2.0.0"",
-                             ""ksp_version_min"": ""1.8.0"",
-                             ""ksp_version_max"": ""1.12.99"",
-                             ""license"":         ""GPL-3.0"",
-                             ""download"":        ""https://github.com/"",
-                             ""depends"": [
-                                 { ""name"": ""Harmony2"" }
-                             ]
-                         }",
-                         @"{
-                             ""spec_version"": ""v1.4"",
-                             ""identifier"":   ""Harmony2"",
-                             ""name"":         ""Harmony 2"",
-                             ""abstract"":     ""A library for patching, replacing and decorating .NET and Mono methods during runtime"",
-                             ""version"":      ""2.2.1.0"",
-                             ""ksp_version_min"": ""1.8.0"",
-                             ""ksp_version_max"": ""1.12.99"",
-                             ""license"":         ""MIT"",
-                             ""download"":        ""https://spacedockinfo/""
-                         }",
-                     },
-                     new string[]
-                     {
-                         @"{
-                             ""spec_version"":    ""v1.4"",
-                             ""identifier"":      ""kOS-EVA"",
-                             ""name"":            ""kOS-EVA"",
-                             ""abstract"":        ""Addon for kOS that allows controlling a kerbal while on EVA"",
-                             ""version"":         ""0.2.0.0"",
-                             ""ksp_version_min"": ""1.8.0"",
-                             ""ksp_version_max"": ""1.12.99"",
-                             ""license"":         ""GPL-3.0"",
-                             ""download"":        ""https://github.com/""
-                         }",
-                     },
-                     "kOS-EVA"),
+        [TestCase(new string[]
+                  {
+                      @"{
+                          ""spec_version"":    ""v1.4"",
+                          ""identifier"":      ""kOS-EVA"",
+                          ""name"":            ""kOS-EVA"",
+                          ""abstract"":        ""Addon for kOS that allows controlling a kerbal while on EVA"",
+                          ""version"":         ""0.2.0.0"",
+                          ""ksp_version_min"": ""1.8.0"",
+                          ""ksp_version_max"": ""1.12.99"",
+                          ""license"":         ""GPL-3.0"",
+                          ""download"":        ""https://github.com/"",
+                          ""depends"": [
+                              { ""name"": ""Harmony2"" }
+                          ]
+                      }",
+                      @"{
+                          ""spec_version"": ""v1.4"",
+                          ""identifier"":   ""Harmony2"",
+                          ""name"":         ""Harmony 2"",
+                          ""abstract"":     ""A library for patching, replacing and decorating .NET and Mono methods during runtime"",
+                          ""version"":      ""2.2.1.0"",
+                          ""ksp_version_min"": ""1.8.0"",
+                          ""ksp_version_max"": ""1.12.99"",
+                          ""license"":         ""MIT"",
+                          ""download"":        ""https://spacedockinfo/""
+                      }",
+                  },
+                  new string[]
+                  {
+                      @"{
+                          ""spec_version"":    ""v1.4"",
+                          ""identifier"":      ""kOS-EVA"",
+                          ""name"":            ""kOS-EVA"",
+                          ""abstract"":        ""Addon for kOS that allows controlling a kerbal while on EVA"",
+                          ""version"":         ""0.2.0.0"",
+                          ""ksp_version_min"": ""1.8.0"",
+                          ""ksp_version_max"": ""1.12.99"",
+                          ""license"":         ""GPL-3.0"",
+                          ""download"":        ""https://github.com/""
+                      }",
+                  },
+                  "kOS-EVA"),
         ]
         public void Constructor_OverlappingModules_HigherPriorityOverrides(string[] modules1,
                                                                            string[] modules2,
@@ -154,6 +154,69 @@ namespace Tests.Core.Registry
                 CollectionAssert.AreEquivalent(new CkanModule[] { avail1.ByVersion(new ModuleVersion("3:1.0"))! },
                                                sorter.LatestIncompatible);
             });
+        }
+
+        [Test]
+        public void Constructor_OnlyCompatibleIsPrerelease_Incompatible()
+        {
+            // Arrange
+            var avail = new AvailableModule(
+                            "BDArmoryContinued",
+                            new string[]
+                            {
+                                @"{
+                                    ""identifier"":     ""BDArmoryContinued"",
+                                    ""version"":        ""2.0"",
+                                    ""ksp_version"":    ""1.12"",
+                                    ""release_status"": ""testing""
+                                }",
+                                @"{
+                                    ""identifier"":  ""BDArmoryContinued"",
+                                    ""version"":     ""1.1"",
+                                    ""ksp_version"": ""1.9"",
+                                }",
+                                @"{
+                                    ""identifier"":  ""BDArmoryContinued"",
+                                    ""version"":     ""1.0"",
+                                    ""ksp_version"": ""1.9"",
+                                }",
+                            }.Select(RelationshipResolverTests.MergeWithDefaults)
+                             .Select(CkanModule.FromJson)
+                             .ToArray());
+            var ident     = avail.AllAvailable().First().identifier;
+            var versCrit  = new GameVersionCriteria(GameVersion.Parse("1.12.5"));
+            var providers = new Dictionary<string, AvailableModule[]>()
+            {
+                { ident, new AvailableModule[] { avail } }
+            };
+            var allAvailable = new Dictionary<string, AvailableModule>[]
+            {
+                new Dictionary<string, AvailableModule>
+                {
+                    { ident, avail }
+                }
+            };
+            var installed = new Dictionary<string, InstalledModule>();
+            var dlls      = new Dictionary<string, string>().Keys;
+            var dlcs      = new Dictionary<string, UnmanagedModuleVersion>();
+            var stability = new StabilityToleranceConfig("");
+
+            // Act
+            var sorter = new CompatibilitySorter(stability, versCrit,
+                                                 allAvailable, providers,
+                                                 installed, dlls, dlcs);
+
+            // Assert
+            CollectionAssert.IsEmpty(sorter.Compatible,
+                                     "No compatible available modules");
+            CollectionAssert.IsEmpty(sorter.LatestCompatible,
+                                     "No latest compatible module");
+            CollectionAssert.AreEquivalent(Enumerable.Repeat(ident, 1),
+                                           sorter.Incompatible.Keys,
+                                           "Incompatible available module");
+            CollectionAssert.AreEquivalent(Enumerable.Repeat(ident, 1),
+                                           sorter.LatestIncompatible.Select(m => m.identifier),
+                                           "Incompatible latest module");
         }
     }
 }

--- a/Tests/Core/Types/ReleaseStatus.cs
+++ b/Tests/Core/Types/ReleaseStatus.cs
@@ -2,6 +2,8 @@ using NUnit.Framework;
 
 using CKAN;
 
+using Tests.Core.Relationships;
+
 namespace Tests.Core.Types
 {
     [TestFixture]
@@ -18,7 +20,7 @@ namespace Tests.Core.Types
             Assert.DoesNotThrow(() =>
             {
                 var module = CkanModule.FromJson(
-                    Relationships.RelationshipResolverTests.MergeWithDefaults(
+                    RelationshipResolverTests.MergeWithDefaults(
                         $@"{{
                             ""identifier"": ""aMod"",
                             ""release_status"": ""{status}""
@@ -38,7 +40,7 @@ namespace Tests.Core.Types
             Assert.Throws<BadMetadataKraken>(delegate
             {
                 var module = CkanModule.FromJson(
-                    Relationships.RelationshipResolverTests.MergeWithDefaults(
+                    RelationshipResolverTests.MergeWithDefaults(
                         $@"{{
                             ""identifier"": ""aMod"",
                             ""release_status"": ""{status}""
@@ -53,7 +55,7 @@ namespace Tests.Core.Types
             Assert.DoesNotThrow(() =>
             {
                 var module = CkanModule.FromJson(
-                    Relationships.RelationshipResolverTests.MergeWithDefaults(
+                    RelationshipResolverTests.MergeWithDefaults(
                         $@"{{
                             ""identifier"": ""aMod""
                         }}"));
@@ -68,7 +70,7 @@ namespace Tests.Core.Types
             Assert.DoesNotThrow(() =>
             {
                 var module = CkanModule.FromJson(
-                    Relationships.RelationshipResolverTests.MergeWithDefaults(
+                    RelationshipResolverTests.MergeWithDefaults(
                         $@"{{
                             ""identifier"": ""aMod"",
                             ""release_status"": null

--- a/Tests/GUI/Model/ModList.cs
+++ b/Tests/GUI/Model/ModList.cs
@@ -70,7 +70,7 @@ namespace Tests.GUI
             using (var inst     = new DisposableKSP())
             using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
             using (var repo     = new TemporaryRepository(
-                                      Core.Relationships.RelationshipResolverTests.MergeWithDefaults(
+                                      RelationshipResolverTests.MergeWithDefaults(
                                           @"{
                                               ""identifier"": ""HiddenMod"",
                                               ""tags"":       [ ""library"" ]
@@ -307,7 +307,7 @@ namespace Tests.GUI
             using (var inst     = new DisposableKSP())
             using (var config   = new FakeConfiguration(inst.KSP, inst.KSP.Name))
             using (var repo     = new TemporaryRepository(
-                                      Core.Relationships.RelationshipResolverTests.MergeWithDefaults(
+                                      RelationshipResolverTests.MergeWithDefaults(
                                           @"{
                                               ""identifier"": ""AnchorMod"",
                                               ""depends"": [


### PR DESCRIPTION
## Problems

- If you set stability tolerance to Stable and do not mark KSP 1.9 or earlier as compatible, BDArmoryContinued disappears completely from the mod list. It can't be found by searching or installed as a dependency.
  Setting your stability tolerance to Testing or marking 1.9 as compatible each make it appear again.
  Reported by @Clayell on Discord.
- If you open CKAN with the option to check for CKAN updates at launch enabled and then leave it open long enough for additional CKAN updates to become available, the Check for updates button in the settings will not find those updates.
  If you close CKAN and re-open it, the latest version will be found.
  Reported by @Clayell on Discord.
- The "Loading installed modules..." freeze fixed in #4671 can still happen in other cases.
  In the sample `registry.json` from Tyler that I studied, a Kopernicus upgrade required a KSPTextureLoader upgrade, but KSPTextureLoader's version was locked by an installed modpack with version-specific dependencies.
  Reported by Discord users sol parsons, solidsnake, Tyler, and Peregrine (plus a few others).
- Sometimes upgrading a group of mods results in a "Mods should have been installed but were not" error. If you click Retry, it works. This was intended as a sanity check for the multithreading logic that performs installation, uninstallation, and removal in parallel with downloads, so it's surprising that it's being hit.
  Reported by various people in various places, none of which I can find now.

## Causes

- BDArmoryContinued has old stable releases compatible with 1.9 and earlier, and a prerelease compatible with 1.9–1.12, so we should treat it as incompatible overall. The `CompatibilitySorter` only checks game version compatibility and so puts this in its "needs more investigation" group since it has dependencies; since the dependencies are all compatible, it eventually goes into the `Compatible` property. But when we later call `LatestAvailable` to retrieve the `CkanModule` that's allegedly compatible, the stability tolerance is checked and none are found, so we have nothing to add to the mod list.
- The update check is cached so we don't constantly hit the network every time you open the settings window. The button currently doesn't bypass that cache.
- The upgradeability algorithm from #4669 still has some opportunities to improve performance after #4671:
  - When a mod is being re-installed, the upgradeability is the same before and after, but the algorithm still treats upgrading and not upgrading as separate cases for such mods, unnecessarily checking redundant branches.
  - If a mod has an upgrade that conflicts with other mods being upgraded in the current branch of the search, the installed version is added to the potential changeset as not-upgradeable. But if that version _also_ conflicts with other mods being upgraded in the current branch of the search, then we don't find that out until we recurse all the way through all the remaining mods and reach the leaf nodes, of which there may be very very many due to the permutative strategy of the search! This results in many `RelationshipResolver`s being created and failing, over and over.
    In Tyler's case, if Kopernicus's upgradeability is checked first, it appears to be upgradeable, but then when we check KSPTextureLoader, it ends up in a group with both a Kopernicus that _requires_ an upgrade and a modpack that _forbids_ an upgrade! No possible permutation of the remaining mods will ever make that solveable, but we still attempt to check them anyway.
- The `skipFiles` option from #4599 excludes mods being reinstalled because their non-install-related metadata changed from the list that we uninstall and reinstall, since no file changes are implicated. This also excluded those mods from the downloading logic, since if we're not unzipping files, we don't need to download the ZIP. However, that exclusion meant that mods that _depend_ on those mods wait forever, because their dependencies never show up in the freshly downloaded list! When the last download finishes, we check whether any mods are still waiting and find those depending mods.
  In Tyler's case, ToolbarController had a metadata update (presumably due to KSP-CKAN/NetKAN#11216), which blocked TUFX and several other mods.

## Motivation

Tyler's modpack had version-specific dependencies, but it probably should not have, as this was blocking present or future upgrades to mods like KSPTextureLoader, Kopernicus, TweakScaleRescaled, B9PartSwitch, and more. If it just happened to end up in front of me, then this probably happens somewhat often.

## Changes

- Now `CompatibilitySorter` also compares `release_status` to the stability tolerance alongside checking game version compatibility. This puts BDArmoryContinued into the `Incompatible` group and property, so it again shows up in the mod list.
  A test is added that fails with the old code and passes with the new code.
- Now when you click Check for updates button, we always explicitly bypass the cache and check the network for a new release.
- Now when the update for a mod is just a re-install, we skip the checks for the installed mod, since they're the same.
- Now before we check upgradeability for a group of mods containing the installed version of a mod, we check whether it conflicts with the other mods being upgraded in the current branch of the search and skip it if it does.
- Now we add any mods from `skipFiles` to the initial list of already installed mods for the parallel downloading logic, so depending mods will have their dependencies satisfied and proceed.
  A test is added that fails with the old code and passes with the new code.
- Now if you install .ckan files containing one or more metapackages with version-specific requirements, a confirmation dialog appears asking whether you're sure you want to pin those mods' versions. If you say yes, then the modpack will be installed as-is. If you say no, then the version requirements are purged before installing, so the latest versions of those mods will be installed, and future upgrades will not be blocked.
