### PR TITLE
Fix freeze on loading installed modules

### DIFF
--- a/Core/GameInstance.cs
+++ b/Core/GameInstance.cs
@@ -372,8 +372,9 @@ namespace CKAN
                     {
                         StartInfo = new ProcessStartInfo()
                         {
-                            FileName  = binary,
-                            Arguments = string.Join(" ", split.Skip(1))
+                            FileName        = binary,
+                            Arguments       = string.Join(" ", split.Skip(1)),
+                            UseShellExecute = true,
                         },
                         EnableRaisingEvents = true
                     };

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -324,72 +324,61 @@ namespace CKAN
 
             if (remainingIdents.Length == 0)
             {
-                log.DebugFormat("Validating upgradability solution: {0}",
+                log.DebugFormat("Found upgradability solution: {0}",
                                 string.Join(", ", partialSolution.Select(m => m.ToString())));
-                // We are a leaf node, return whatever we received if it is a valid solution
-                if (partialSolution.All(tuple => !tuple.upgradeable)
-                    || Utilities.DefaultIfThrows(() =>
-                           new RelationshipResolver(partialSolution.Where(tuple => tuple.upgradeable)
-                                                                   .Select(tuple => tuple.module),
-                                                    partialSolution.Where(tuple => tuple.upgradeable)
-                                                                   .Select(tuple => tuple.module.identifier)
-                                                                   .Select(querier.GetInstalledVersion)
-                                                                   .OfType<CkanModule>(),
-                                                    RelationshipResolverOptions.DependsOnlyOpts(instance.StabilityToleranceConfig),
-                                                    querier, instance.Game, instance.VersionCriteria()))
-                       is not null)
-                {
-                    yield return partialSolution;
-                }
-                yield break;
+                // We are a leaf node, return whatever we received
+                yield return partialSolution;
             }
-            foreach (var ident in remainingIdents)
+            else
             {
-                var imod = querier.GetInstalledVersion(ident);
-                var otherIdents = remainingIdents.Where(i => i != ident)
-                                                 .ToArray();
-                // Have to check HasUpdate again to account for the additions to partialSolution
-                if (!heldIdents.Contains(ident)
-                    && querier.HasUpdate(ident, instance.StabilityToleranceConfig, instance, filters,
-                                         !ignoreMissingIdents?.Contains(ident) ?? true,
-                                         out CkanModule? latest,
-                                         partialMods))
+                foreach (var ident in remainingIdents)
                 {
-                    // Upgrading this mod is allowed so far, use it to check the remaining mods
+                    var imod = querier.GetInstalledVersion(ident);
+                    var otherIdents = remainingIdents.Where(i => i != ident)
+                                                     .ToArray();
+                    // Have to check HasUpdate again to account for the additions to partialSolution
+                    if (!heldIdents.Contains(ident)
+                        && querier.HasUpdate(ident, instance.StabilityToleranceConfig, instance, filters,
+                                             !ignoreMissingIdents?.Contains(ident) ?? true,
+                                             out CkanModule? latest,
+                                             partialMods))
+                    {
+                        // Upgrading this mod is allowed so far, use it to check the remaining mods
+                        foreach (var solution in querier.FindUpgradeabilitySolutions(
+                                                     instance, otherIdents,
+                                                     partialSolution.Concat(Enumerable.Repeat((upgradeable: true,
+                                                                                               module:      latest),
+                                                                                              1))
+                                                                    .ToArray(),
+                                                     filters, heldIdents, ignoreMissingIdents))
+                        {
+                            yield return solution;
+                        }
+                        if (imod == latest)
+                        {
+                            log.DebugFormat("Update for {0} is a re-install, skipping installed branch",
+                                            imod);
+                            continue;
+                        }
+                    }
+
+                    if (imod is { IsDLC: false} && !imod.DependsAndConflictsOK(partialMods))
+                    {
+                        log.DebugFormat("Installed {0} not compatible with partial solution, rejecting installed branch",
+                                        imod);
+                        continue;
+                    }
+
                     foreach (var solution in querier.FindUpgradeabilitySolutions(
                                                  instance, otherIdents,
-                                                 partialSolution.Concat(Enumerable.Repeat((upgradeable: true,
-                                                                                           module:      latest),
-                                                                                          1))
-                                                                .ToArray(),
+                                                 imod is { IsDLC: false }
+                                                     ? partialSolution.Append((false, imod))
+                                                                      .ToArray()
+                                                     : partialSolution,
                                                  filters, heldIdents, ignoreMissingIdents))
                     {
                         yield return solution;
                     }
-                    if (imod == latest)
-                    {
-                        log.DebugFormat("Update for {0} is a re-install, skipping installed branch",
-                                        imod);
-                        continue;
-                    }
-                }
-
-                if (imod is { IsDLC: false} && !imod.DependsAndConflictsOK(partialMods))
-                {
-                    log.DebugFormat("Installed {0} not compatible with partial solution, rejecting installed branch",
-                                    imod);
-                    continue;
-                }
-
-                foreach (var solution in querier.FindUpgradeabilitySolutions(
-                                             instance, otherIdents,
-                                             imod is { IsDLC: false }
-                                                 ? partialSolution.Append((false, imod))
-                                                                  .ToArray()
-                                                 : partialSolution,
-                                             filters, heldIdents, ignoreMissingIdents))
-                {
-                    yield return solution;
                 }
             }
         }

--- a/GUI/Controls/ManageMods.cs
+++ b/GUI/Controls/ManageMods.cs
@@ -1515,11 +1515,10 @@ namespace CKAN.GUI
                     modules.Select(module =>
                                        // "Upgrade" to latest metadata for same module version
                                        // (avoids removing and re-installing dependencies)
-                                       new ModUpgrade(module,
-                                                      registry.GetModuleByVersion(module.identifier,
-                                                                                  module.version)
-                                                              ?? module,
-                                                      true, false, true, config)
+                                       new ModReinstall(registry.GetModuleByVersion(module.identifier,
+                                                                                    module.version)
+                                                        ?? module,
+                                                        true, false, true, config)
                                        as ModChange)
                            .ToList(),
                     null);

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -126,9 +126,9 @@ namespace CKAN.GUI
                 var needRemoveForAuto = changes.All(ch => ch.ChangeType == GUIModChangeType.Install
                                                           || ch.IsAutoRemoval);
 
-                var skipFiles = changes.OfType<ModUpgrade>()
+                var skipFiles = changes.OfType<ModReinstall>()
                                        .Where(ch => ch.SkipReinstallingFiles)
-                                       .Select(ch => ch.targetMod)
+                                       .Select(ch => ch.Mod)
                                        .ToHashSet();
 
                 // First compose sets of what the user wants installed, upgraded, and removed.

--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -320,7 +320,9 @@ namespace CKAN.GUI
         public IEnumerable<ModChange> GetModChanges(bool upgradeChecked,
                                                     bool replaceChecked,
                                                     bool metadataChanged,
-                                                    bool installedFilesChanged)
+                                                    bool installMetadataChanged,
+                                                    GameInstance instance,
+                                                    HashSet<string> filters)
         {
             var installed = InstalledMod?.Module;
             if (replaceChecked)
@@ -340,7 +342,6 @@ namespace CKAN.GUI
                 {
                     yield return new ModUpgrade(Mod,
                                                 SelectedMod,
-                                                false, false, false,
                                                 ServiceLocator.Container.Resolve<IConfiguration>());
                 }
                 else
@@ -360,10 +361,9 @@ namespace CKAN.GUI
             else if (upgradeChecked && SelectedMod != null)
             {
                 // Reinstall
-                yield return new ModUpgrade(Mod,
-                                            SelectedMod,
-                                            false, metadataChanged, installedFilesChanged,
-                                            ServiceLocator.Container.Resolve<IConfiguration>());
+                yield return new ModReinstall(Mod, false, metadataChanged,
+                                              installMetadataChanged || (!InstalledMod?.AllFilesExist(instance, filters) ?? false),
+                                              ServiceLocator.Container.Resolve<IConfiguration>());
             }
         }
 

--- a/GUI/Model/ModChange.cs
+++ b/GUI/Model/ModChange.cs
@@ -139,45 +139,54 @@ namespace CKAN.GUI
     #endif
     public class ModUpgrade : ModChange
     {
-        public ModUpgrade(CkanModule       mod,
-                          CkanModule       targetMod,
-                          bool             userReinstall,
-                          bool             metadataChanged,
-                          bool             installedFilesChanged,
-                          IConfiguration   config)
+        public ModUpgrade(CkanModule     mod,
+                          CkanModule     targetMod,
+                          IConfiguration config)
             : base(mod, GUIModChangeType.Update, config)
         {
-            this.targetMod             = targetMod;
-            this.userReinstall         = userReinstall;
-            this.metadataChanged       = metadataChanged;
-            this.installedFilesChanged = installedFilesChanged;
+            this.targetMod = targetMod;
         }
 
         public override string NameAndStatus(NetModuleCache cache)
             => cache.DescribeAvailability(config, targetMod);
 
         public override string Description
-            => IsReinstall
-                ? userReinstall ? Properties.Resources.MainChangesetReinstallUser
-                                : metadataChanged ? Properties.Resources.MainChangesetReinstallMetadataChanged
-                                                  : Properties.Resources.MainChangesetReinstallMissing
-                : string.Format(Properties.Resources.MainChangesetUpdateSelected,
-                                targetMod.version);
+            => string.Format(Properties.Resources.MainChangesetUpdateSelected,
+                             targetMod.version);
 
         /// <summary>
         /// The target version for upgrading
         /// </summary>
         public CkanModule targetMod;
+    }
 
-        private bool IsReinstall
-            => targetMod.identifier == Mod.identifier
-                && targetMod.version == Mod.version;
-
-        public bool SkipReinstallingFiles
-            => metadataChanged && !installedFilesChanged;
+    #if NET5_0_OR_GREATER
+    [SupportedOSPlatform("windows")]
+    #endif
+    public class ModReinstall : ModChange
+    {
+        public ModReinstall(CkanModule     mod,
+                            bool           userReinstall,
+                            bool           metadataChanged,
+                            bool           reinstallFiles,
+                            IConfiguration config)
+            : base(mod, GUIModChangeType.Update, config)
+        {
+            this.userReinstall   = userReinstall;
+            this.metadataChanged = metadataChanged;
+            this.reinstallFiles  = reinstallFiles;
+        }
 
         private readonly bool userReinstall;
         private readonly bool metadataChanged;
-        private readonly bool installedFilesChanged;
+        private readonly bool reinstallFiles;
+
+        public override string Description
+            => userReinstall   ? Properties.Resources.MainChangesetReinstallUser
+             : metadataChanged ? Properties.Resources.MainChangesetReinstallMetadataChanged
+             :                   Properties.Resources.MainChangesetReinstallMissing;
+
+        public bool SkipReinstallingFiles
+            => !userReinstall && metadataChanged && !reinstallFiles;
     }
 }

--- a/GUI/Model/ModList.cs
+++ b/GUI/Model/ModList.cs
@@ -389,8 +389,14 @@ namespace CKAN.GUI
                                                        DataGridViewColumn? replaceCol)
         {
             log.Debug("Computing user changeset");
+            var instFilters = ServiceLocator.Container
+                                            .Resolve<IConfiguration>()
+                                            .GetGlobalInstallFilters(instance.Game)
+                                            .Concat(instance.InstallFilters)
+                                            .ToHashSet();
             var modChanges = full_list_of_mod_rows.Values
-                                                  .SelectMany(row => rowChanges(registry, row, upgradeCol, replaceCol))
+                                                  .SelectMany(row => rowChanges(registry, row, upgradeCol, replaceCol,
+                                                                                instance, instFilters))
                                                   .ToHashSet();
 
             // Inter-mod dependencies can block some upgrades, which can sometimes but not always
@@ -433,7 +439,9 @@ namespace CKAN.GUI
         private static IEnumerable<ModChange> rowChanges(IRegistryQuerier    registry,
                                                          DataGridViewRow     row,
                                                          DataGridViewColumn? upgradeCol,
-                                                         DataGridViewColumn? replaceCol)
+                                                         DataGridViewColumn? replaceCol,
+                                                         GameInstance        instance,
+                                                         HashSet<string>     filters)
             => row.Tag is GUIMod gmod
                    ? gmod.GetModChanges(upgradeCol?.Visible == true
                                         && row.Cells[upgradeCol.Index] is DataGridViewCheckBoxCell upgradeCell
@@ -442,7 +450,7 @@ namespace CKAN.GUI
                                         && row.Cells[replaceCol.Index] is DataGridViewCheckBoxCell replaceCell
                                         && replaceCell.Value is true,
                                         registry.MetadataChanged(gmod.Identifier, out bool installedFilesChanged),
-                                        installedFilesChanged)
+                                        installedFilesChanged, instance, filters)
                    : Enumerable.Empty<ModChange>();
 
         public static Tuple<ICollection<ModChange>, Dictionary<CkanModule, string>, List<string>> ComputeFullChangeSetFromUserChangeSet(

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -215,7 +215,7 @@ Are you sure you want to install them? Cancelling will abort the entire installa
 Do you want to override the specific-version requirements?</value></data>
   <data name="MetapackagePurgeRelationshipVersions" xml:space="preserve"><value>Allow any mod versions</value></data>
   <data name="MetapackageKeepRelationshipVersions" xml:space="preserve"><value>Keep the mod version requirements</value></data>
-  <data name="MainChangesetUpdateSelected" xml:space="preserve"><value>Update selected by user to version {0}.</value></data>
+  <data name="MainChangesetUpdateSelected" xml:space="preserve"><value>Update to version {0}.</value></data>
   <data name="MainChangesetReinstallMetadataChanged" xml:space="preserve"><value>Re-install (metadata changed)</value></data>
   <data name="MainChangesetReinstallMissing" xml:space="preserve"><value>Re-install (missing folders or files)</value></data>
   <data name="MainChangesetReinstallUser" xml:space="preserve"><value>Re-install (user requested)</value></data>

--- a/Tests/Core/Registry/Registry.cs
+++ b/Tests/Core/Registry/Registry.cs
@@ -475,6 +475,89 @@ namespace Tests.Core.Registry
             }
         }
 
+        [TestCase(new string[] { },
+                  new string[] { },
+                  new string[] { }),
+         TestCase(new string[]
+                  {
+                      @"{
+                          ""identifier"": ""KnownMod1""
+                      }",
+                      @"{
+                          ""identifier"": ""KnownMod2""
+                      }",
+                      @"{
+                          ""identifier"": ""MakingHistory-DLC"",
+                          ""version"":    ""2.0"",
+                          ""kind"":       ""dlc""
+                      }",
+                  },
+                  new string[] { "KnownMod1", "KnownMod2", "UnknownMod1", "UnknownMod2" },
+                  new string[] { "KnownMod1 1.0", "KnownMod2 1.0" }),
+         TestCase(new string[]
+                  {
+                      @"{
+                          ""identifier"": ""Scatterer"",
+                          ""depends"": [
+                              {
+                                  ""name"": ""Scatterer-config""
+                              },
+                              {
+                                  ""name"": ""Scatterer-sunflare""
+                              }
+                          ]
+                      }",
+                      @"{
+                          ""identifier"": ""Scatterer-config""
+                      }",
+                      @"{
+                          ""identifier"": ""Scatterer-config-alternate"",
+                          ""provides"":   [ ""Scatterer-config"" ]
+                      }",
+                      @"{
+                          ""identifier"": ""Scatterer-sunflare""
+                      }",
+                      @"{
+                          ""identifier"": ""Scatterer-sunflare-alternate"",
+                          ""provides"": [ ""Scatterer-sunflare"" ]
+                      }",
+                  },
+                  new string[] { "Scatterer" },
+                  new string[] { "Scatterer 1.0" })
+        ]
+        public void UpgradeableModules_ManuallyInstalled_Upgradeable(
+                string[] availableModules,
+                string[] manuallyInstalledIdents,
+                string[] expectedUpgradeable)
+        {
+            // Arrange
+            var user = new NullUser();
+            using (var gameInstWrapper = new DisposableKSP())
+            using (var repo = new TemporaryRepository(RelationshipResolverTests.MergeWithDefaults(availableModules)
+                                                                               .ToArray()))
+            using (var repoData = new TemporaryRepositoryData(user, repo.repo))
+            {
+                var registry = new CKAN.Registry(repoData.Manager, repo.repo);
+                registry.SetDlcs(new Dictionary<string, UnmanagedModuleVersion>()
+                                 {
+                                     {
+                                         "MakingHistory-DLC",
+                                         new UnmanagedModuleVersion("1.0")
+                                     },
+                                 });
+                registry.SetDlls(manuallyInstalledIdents.ToDictionary(ident => ident,
+                                                                      ident => $"{ident}/{ident}.dll"));
+
+                // Act
+                var upgradeable = registry.UpgradeableModules(gameInstWrapper.KSP,
+                                                              new HashSet<string>());
+
+                // Assert
+                CollectionAssert.AreEquivalent(expectedUpgradeable,
+                                               upgradeable.Select(m => m.ToString()));
+            }
+        }
+
         [Test,
             // Empty registry, return nothing
             TestCase(new string[] { },

--- a/Tests/GUI/Model/GUIMod.cs
+++ b/Tests/GUI/Model/GUIMod.cs
@@ -265,6 +265,69 @@ namespace Tests.GUI
                 Assert.IsFalse(sut.Equals(other2));
             }
         }
+
+        [Test]
+        public void GetModChanges_Replace_Works()
+        {
+            // Arrange
+            var repoData = new RepositoryDataManager();
+            using (var inst     = new DisposableKSP())
+            using (var cacheDir = new TemporaryDirectory())
+            using (var cache    = new NetModuleCache(cacheDir))
+            {
+                var sut = new GUIMod(TestData.ModuleManagerModule(), repoData, Registry.Empty(repoData),
+                                     inst.KSP.StabilityToleranceConfig, inst.KSP,
+                                     cache, false, true, true);
+
+                // Act
+                var changes = sut.GetModChanges(false, true, false, false, inst.KSP, new HashSet<string>())
+                                 .ToArray();
+
+                // Assert
+                Assert.AreEqual(1, changes.Length);
+                Assert.AreEqual(GUIModChangeType.Replace, changes[0].ChangeType);
+            }
+        }
+
+        [Test]
+        public void GetModChanges_Reinstall_Works()
+        {
+            // Arrange
+            var user = new NullUser();
+            using (var inst     = new DisposableKSP())
+            using (var repo     = new TemporaryRepository(RelationshipResolverTests.MergeWithDefaults(
+                                      @"{
+                                          ""identifier"": ""InstalledMod"",
+                                          ""version"":    ""1.0""
+                                      }",
+                                      @"{
+                                          ""identifier"": ""InstalledMod"",
+                                          ""version"":    ""2.0""
+                                      }")
+                                     .ToArray()))
+            using (var repoData = new TemporaryRepositoryData(user, repo.repo))
+            using (var cacheDir = new TemporaryDirectory())
+            using (var cache    = new NetModuleCache(cacheDir))
+            {
+                var registry = new CKAN.Registry(repoData.Manager, repo.repo);
+                var installed = registry.GetModuleByVersion("InstalledMod", "1.0")!;
+                var upgrade   = registry.GetModuleByVersion("InstalledMod", "2.0")!;
+                registry.RegisterModule(installed, Array.Empty<string>(), inst.KSP, false);
+
+                var sut = new GUIMod(registry.InstalledModule("InstalledMod")!,
+                                     repoData.Manager, registry,
+                                     inst.KSP.StabilityToleranceConfig, inst.KSP,
+                                     cache, false, true, true);
+
+                // Act
+                var changes = sut.GetModChanges(true, false, true, true, inst.KSP, new HashSet<string>())
+                                 .ToArray();
+
+                // Assert
+                Assert.AreEqual(1, changes.Length);
+                Assert.AreEqual(GUIModChangeType.Update, changes[0].ChangeType);
+            }
+        }
     }
 }
 

--- a/Tests/GUI/Model/ModChangeTests.cs
+++ b/Tests/GUI/Model/ModChangeTests.cs
@@ -53,15 +53,8 @@ namespace Tests.GUI
             }
         }
 
-        [TestCase(false, false, false, "Re-install (missing folders or files)"),
-         TestCase(false, true,  false, "Re-install (metadata changed)"),
-         TestCase(false, true,  true,  "Re-install (metadata changed)"),
-         TestCase(true,  false, false, "Re-install (user requested)"),
-         TestCase(true,  true,  false, "Re-install (user requested)")]
-        public void AllProperties_Upgrade_Correct(bool   userReinstall,
-                                                  bool   metadataChanged,
-                                                  bool   installedFilesChanged,
-                                                  string reason)
+        [Test]
+        public void AllProperties_Upgrade_Correct()
         {
             // Arrange
             var user = new NullUser();
@@ -73,25 +66,63 @@ namespace Tests.GUI
                 // Act
                 var sut = new ModUpgrade(TestData.ModuleManagerModule(),
                                          TestData.ModuleManagerModule(),
-                                         userReinstall, metadataChanged, installedFilesChanged,
                                          config);
 
                 // Assert
                 Assert.IsTrue(sut.IsUserRequested);
-                Assert.AreEqual(metadataChanged && !installedFilesChanged,
+                Assert.AreEqual("Update to version 2.5.1.", sut.Description);
+                Assert.AreEqual("Update ModuleManager 2.5.1 (Update to version 2.5.1.)", sut.ToString());
+                Assert.AreEqual(new ModUpgrade(TestData.ModuleManagerModule(),
+                                               TestData.ModuleManagerModule(),
+                                               config),
+                                sut);
+                Assert.AreNotEqual(new ModChange(TestData.BurnControllerModule(),
+                                                 GUIModChangeType.Update,
+                                                 config),
+                                   sut);
+                Assert.AreNotEqual(new ModChange(TestData.ModuleManagerModule(),
+                                                 GUIModChangeType.Install,
+                                                 config),
+                                   sut);
+            }
+        }
+
+        [TestCase(false, false, false, "Re-install (missing folders or files)"),
+         TestCase(false, true,  false, "Re-install (metadata changed)"),
+         TestCase(false, true,  true,  "Re-install (metadata changed)"),
+         TestCase(true,  false, false, "Re-install (user requested)"),
+         TestCase(true,  true,  false, "Re-install (user requested)")]
+        public void AllProperties_Reinstall_Correct(bool   userReinstall,
+                                                    bool   metadataChanged,
+                                                    bool   reinstallFiles,
+                                                    string reason)
+        {
+            // Arrange
+            var user = new NullUser();
+            using (var inst    = new DisposableKSP())
+            using (var config  = new FakeConfiguration(inst.KSP, inst.KSP.Name))
+            using (var manager = new GameInstanceManager(user, config))
+            {
+
+                // Act
+                var sut = new ModReinstall(TestData.ModuleManagerModule(),
+                                           userReinstall, metadataChanged, reinstallFiles,
+                                           config);
+
+                // Assert
+                Assert.IsTrue(sut.IsUserRequested);
+                Assert.AreEqual(!userReinstall && metadataChanged && !reinstallFiles,
                                 sut.SkipReinstallingFiles);
                 Assert.AreEqual(reason, sut.Description);
                 Assert.AreEqual($"Update ModuleManager 2.5.1 ({reason})",
                                 sut.ToString());
-                Assert.AreEqual(new ModUpgrade(TestData.ModuleManagerModule(),
-                                               TestData.ModuleManagerModule(),
-                                               userReinstall, metadataChanged, false,
-                                               config),
+                Assert.AreEqual(new ModReinstall(TestData.ModuleManagerModule(),
+                                                 userReinstall, metadataChanged, false,
+                                                 config),
                                 sut);
-                Assert.AreNotEqual(new ModUpgrade(TestData.BurnControllerModule(),
-                                                  TestData.BurnControllerModule(),
-                                                  userReinstall, metadataChanged, false,
-                                                  config),
+                Assert.AreNotEqual(new ModReinstall(TestData.BurnControllerModule(),
+                                                    userReinstall, metadataChanged, false,
+                                                    config),
                                    sut);
             }
         }

--- a/Tests/GUI/Model/ModList.cs
+++ b/Tests/GUI/Model/ModList.cs
@@ -32,7 +32,7 @@ namespace Tests.GUI
     {
         public ModListTests()
         {
-            this.graphics = Graphics.FromImage(EmbeddedImages.apply);
+            graphics = Graphics.FromImage(EmbeddedImages.apply);
         }
 
         [Test]
@@ -912,7 +912,7 @@ namespace Tests.GUI
             => Enumerable.Range(1, numCheckboxCols)
                          .Select(i => (DataGridViewColumn)new DataGridViewCheckBoxColumn())
                          .Concat(Enumerable.Range(1, numTextCols)
-                         .Select(i => new DataGridViewTextBoxColumn()))
+                                           .Select(i => new DataGridViewTextBoxColumn()))
                          .ToArray();
 
     }

--- a/Tests/GUI/ThreadSafetyTests.cs
+++ b/Tests/GUI/ThreadSafetyTests.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Windows.Forms;
 
 using Mono.Cecil;
-using Mono.Cecil.Cil;
 using NUnit.Framework;
 
 using CKAN.Extensions;

--- a/Tests/MonoCecilAnalysisTestsBase.cs
+++ b/Tests/MonoCecilAnalysisTestsBase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Reflection;
 
 using Mono.Cecil;
 using Mono.Cecil.Cil;
@@ -64,6 +65,22 @@ namespace Tests
                       ?.Instructions
                        .Where(instr => callOpCodes.Contains(instr.OpCode.Name))
                       ?? Enumerable.Empty<Instruction>();
+
+        protected static Dictionary<string, MethodDefinition> AllMethodsByFullyQualifiedName(IEnumerable<Assembly> assemblies)
+            => assemblies.Select(a => ModuleDefinition.ReadModule(a.Location))
+                         .SelectMany(m => m.Types
+                                           .SelectMany(GetAllNestedTypes)
+                                           .SelectMany(t => t.Methods)
+                                           .Where(m => m.HasBody)
+                                           .SelectMany(GetMethodAndTasks))
+                         .GroupBy(FullyQualifiedName)
+                         .Where(grp => grp.Count() == 1)
+                         .ToDictionary(grp => grp.Key,
+                                       grp => grp.Single());
+
+        private static IEnumerable<MethodDefinition> GetMethodAndTasks(MethodDefinition meth)
+            => Enumerable.Repeat(meth, 1)
+                         .Concat(FindStartedTasks(meth).Select(stack => stack.Last()));
 
         // Property setters are virtual and have references instead of definitions
         private static MethodDefinition? GetSetterDef(MethodReference? mr)

--- a/Tests/ProcessStartInfoTests.cs
+++ b/Tests/ProcessStartInfoTests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Reflection;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using NUnit.Framework;
+
+using CKAN.Extensions;
+
+namespace Tests
+{
+    [TestFixture]
+    public class ProcessStartInfoTests : MonoCecilAnalysisBase
+    {
+        [TestCase(new object[]
+                  {
+                      typeof(CKAN.NullUser),
+                      typeof(CKAN.CmdLine.MainClass),
+                      typeof(CKAN.ConsoleUI.ConsoleCKAN),
+                      typeof(CKAN.NetKAN.Program),
+                      #if NETFRAMEWORK || WINDOWS
+                      typeof(CKAN.AutoUpdateHelper.Program),
+                      typeof(CKAN.GUI.Main),
+                      #endif
+                  })]
+        public void Assemblymodule_ProcessStartInfo_UseShellExecuteAlwaysSetExplicitly(object[] anchorTypes)
+        {
+            // Arrange
+            var methodsByName = AllMethodsByFullyQualifiedName(anchorTypes.OfType<Type>()
+                                                                          .Select(Assembly.GetAssembly)
+                                                                          .OfType<Assembly>());
+
+            // Act / Assert
+            Assert.Multiple(() =>
+            {
+                foreach ((string name, MethodDefinition meth) in methodsByName)
+                {
+                    foreach (var newObj in meth.Body
+                                               .Instructions
+                                               .Where(i => i.OpCode == OpCodes.Newobj
+                                                           && i.Operand is MethodReference
+                                                           {
+                                                               DeclaringType: { FullName: "System.Diagnostics.ProcessStartInfo" }
+                                                           }))
+                    {
+                        Assert.IsTrue(PropertySets(newObj).Any(s => s.Operand is MethodReference { Name: "set_UseShellExecute" }),
+                                      $"{name} creates ProcessStartInfo without setting UseShellExecute, which defaults to true in .NET Framework and false in .NET Core");
+                    }
+                }
+            });
+        }
+
+        private static IEnumerable<Instruction> PropertySets(Instruction newObj)
+            => newObj.Operand is MethodReference { DeclaringType: { FullName: var typeName } }
+                   ? newObj.TraverseNodes(i => i.Next)
+                           .Where(i => i.OpCode == OpCodes.Callvirt
+                                       && i.Operand is MethodReference methRef
+                                       && methRef.DeclaringType.FullName == typeName
+                                       && methRef.Name.StartsWith("set_"))
+                   : Enumerable.Empty<Instruction>();
+    }
+}

--- a/Tests/StringFormatSafetyTests.cs
+++ b/Tests/StringFormatSafetyTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Linq;
 using System.Text.RegularExpressions;
+#if NETFRAMEWORK || NETSTANDARD2_0
 using System.Collections.Generic;
+#endif
 using System.Reflection;
 using System.Diagnostics.CodeAnalysis;
 
@@ -29,21 +31,12 @@ namespace Tests
         public void AssemblyModule_StringSyntaxCompositeFormat_SameOrLiteralsOnly(object[] types)
         {
             // Arrange
-            var methodsByName = types.OfType<Type>()
-                                     .Select(t => Assembly.GetAssembly(t))
-                                     .OfType<Assembly>()
-                                     .Select(a => ModuleDefinition.ReadModule(a.Location))
-                                     .SelectMany(m => m.Types
-                                                       .SelectMany(GetAllNestedTypes)
-                                                       .SelectMany(t => t.Methods)
-                                                       .SelectMany(GetMethodAndTasks))
-                                     .GroupBy(FullyQualifiedName)
-                                     .Where(grp => grp.Count() == 1)
-                                     .ToDictionary(grp => grp.Key,
-                                                   grp => grp.Single());
-            var specialNames = methodsByName.Values.Where(AnyParamHasStringSyntaxAttribute)
-                                                   .Select(FullyQualifiedName)
-                                                   .ToHashSet();
+            var methodsByName = AllMethodsByFullyQualifiedName(types.OfType<Type>()
+                                                                    .Select(Assembly.GetAssembly)
+                                                                    .OfType<Assembly>());
+            var specialNames = methodsByName.Where(kvp => AnyParamHasStringSyntaxAttribute(kvp.Value))
+                                            .Select(kvp => kvp.Key)
+                                            .ToHashSet();
 
             // Act / Assert
             Assert.Multiple(() =>
@@ -73,15 +66,15 @@ namespace Tests
                        Operand: MethodReference mRef,
                    } => FullyQualifiedName(mRef),
                    {
-                       OpCode:  {Name: "ldstr"},
+                       OpCode:  { Name: "ldstr" },
                        Operand: string s,
                    } => $"literal \"{s}\"",
                    {
-                       OpCode:  {Name: "ldfld"},
+                       OpCode:  { Name: "ldfld" },
                        Operand: FieldReference fRef,
                    } => $"field \"{fRef.Name}\"",
                    {
-                       OpCode: {Name: string a},
+                       OpCode: { Name: string a },
                    } => ldargPattern.TryMatch(a, out Match? argM)
                         && int.TryParse(argM.Groups["argNum"].Value, out int argNum)
                         && argNum > 0 && argNum <= parent.Parameters.Count
@@ -101,20 +94,15 @@ namespace Tests
                       RegexOptions.Compiled);
 
         private static bool IsEmptyArray(Instruction instr)
-            => instr.OpCode.Name == "call"
-                && instr.Operand is MethodReference mRef
-                && mRef.Name == "Empty";
+            => instr.OpCode == OpCodes.Call
+               && instr.Operand is MethodReference { Name: "Empty" };
 
         private static bool IsI18nResource(Instruction instr)
             => instr.Operand is MethodReference mRef
-                && FullyQualifiedName(mRef).Contains(".Properties.Resources.");
+               && FullyQualifiedName(mRef).Contains(".Properties.Resources.");
 
         private static bool IsStringLiteral(Instruction instr)
-            => instr.OpCode.Name == "ldstr" && instr.Operand is string;
-
-        private static IEnumerable<MethodDefinition> GetMethodAndTasks(MethodDefinition meth)
-            => Enumerable.Repeat(meth, 1)
-                         .Concat(FindStartedTasks(meth).Select(stack => stack.Last()));
+            => instr.OpCode == OpCodes.Ldstr && instr.Operand is string;
 
         private static readonly Type strSynAttrib = typeof(StringSyntaxAttribute);
 


### PR DESCRIPTION
## Problems

- If you have a bunch of manually installed mods (or a previously corrupted `registry.json`, causing your installed mods to be forgotten), the "Loading installed modules" step hangs in the current dev build.
- If an installed mod has _both_ changed metadata _and_ missing files, you have to reinstall it twice to resolve both of those issues, once for the changed metadata and once to reinstall the files.
  Noticed while investigating the above issue with other users' `registry.json` files.
- Launching the game via the `steam://` options doesn't work in `ckan-windows.exe` (but still works fine in `ckan.exe`).
  Reported by Discord user DangerNoodle (plus a few others before we figured out what was happening).

## Causes

- The improved upgradeability logic from #4669 checks each possible solution with `RelationshipResolver`. For installs with lots of AD mods, this commonly throws `TooManyModsProvideKraken` to ask the user to choose dependencies, and if you suppress this, the missing dependency still throws `InconsistentKraken`. This causes every solution to be rejected, which is usually incorrect, but more importantly balloons the number of solutions we need to check to a very large number.
- The selective file reinstallation logic from #4599 neglected to check for missing files.
- <https://learn.microsoft.com/en-us/dotnet/core/compatibility/fx-core#change-in-default-value-of-useshellexecute>
  Microsoft changed the default of `ProcessStartInfo.UseShellExecute` between .NET Framework and .NET Core. If this property isn't specified, `Process.Start` behaves differently on the two target frameworks, handling URLs properly in Framework but not in Core. The call that launches the game doesn't set this property.

## Changes

- Now the upgradeability solutions are no longer validated with `RelationshipResolver`, because that just can't work. This will allow fully AD mod lists to load without freezing, but in exchange we are giving up the ability to correctly assess upgradeability if some solutions should be blocked by newly added dependencies or conflicts. This will have to be handled later when the user actually tries to proceed with the upgrade.
  A test is added to exercise this.
  Fixes #4692.
- Now when determining which mods don't need their files reinstalled, we check whether any files are missing. If any are, we still include that mod.
- Now we set `ProcessStartInfo.UseShellExecute` to `true` when launching the game, so the `net10.0` build will be able to handle URLs properly.
  A test is added that analyzes our assemblies with `Mono.Cecil` to find any instantiations of `ProcessStartInfo` that are not followed by calls to `ProcessStartInfo.set_UseShellExecute`, which passes with the new code and fails with the old code.
